### PR TITLE
Fix selected color management to preserve selection outside of slot focus

### DIFF
--- a/dev/src/App.svelte
+++ b/dev/src/App.svelte
@@ -40,7 +40,7 @@
 
 <main style="--bgColor:{bgColor}">
 	<div class="container">
-		<Palette {colors} allowDuplicates allowDeletion showTransparentSlot maxColors={30} on:select={({ detail: { color } }) => (bgColor = color)} />
+		<Palette {colors} selectedColor={bgColor} allowDuplicates allowDeletion showTransparentSlot maxColors={30} on:select={({ detail: { color } }) => (bgColor = color)} />
 		<hr />
 		<form on:submit|preventDefault={_onSubmit}>
 			<Palette {colors}>

--- a/src/Palette.svelte
+++ b/src/Palette.svelte
@@ -50,7 +50,7 @@
 		{#if showTransparentSlot}
 			<li data-testid="__palette-row__">
 				<slot name="transparent-slot">
-					<PaletteSlot emptyAriaLabel='transparent' on:click={_onSlotSelect} />
+					<PaletteSlot emptyAriaLabel='transparent' selected={selectedColor === null} on:click={_onSlotSelect} />
 				</slot>
 			</li>
 		{/if}
@@ -67,7 +67,7 @@
 				}}
 			>
 				<slot name="slot" {color}>
-					<PaletteSlot data-testid="__palette-slot__" {color} on:click={_onSlotSelect} />
+					<PaletteSlot data-testid="__palette-slot__" {color} selected={color === selectedColor} on:click={_onSlotSelect} />
 				</slot>
 			</li>
 		{/each}

--- a/src/PaletteSlot.svelte
+++ b/src/PaletteSlot.svelte
@@ -6,6 +6,7 @@
 	import { resolveClass } from './utils'
 
 	export let color = null
+	export let selected = false
 	export let disabled = false
 	export let emptyAriaLabel = 'No color'
 
@@ -25,6 +26,7 @@
 	style="--color:{color}; --outerBorderColor:{color || '#aaa'};"
 	class={resolveClass([
 		[!color, 'empty'],
+		[selected, 'selected'],
 		[!disabled, 'clickable'],
 	])}
 	{disabled}
@@ -47,7 +49,7 @@
 		background-color: var(--color);
 	}
 
-	button:focus {
+	button.selected {
 		box-shadow: 0 0 0 0.1rem #fff, 0 0 0 0.25rem var(--outerBorderColor);
 	}
 

--- a/src/__tests__/Palette.test.js
+++ b/src/__tests__/Palette.test.js
@@ -37,7 +37,7 @@ describe('Palette', () => {
 		expect(getByTestId('__palette-tooltip__')).toBeInTheDocument()
 	})
 
-	it('Displays transparent slot if allowDeletion is truthy', async () => {
+	it('Displays transparent slot if showTransparentSlot is truthy', async () => {
 		const onSelect = jest.fn()
 		const colors = ['#ff0', '#0ff', '#f0f']
 		const { getAllByTestId, component } = render(Palette, {

--- a/src/__tests__/PaletteSlot.test.js
+++ b/src/__tests__/PaletteSlot.test.js
@@ -56,4 +56,10 @@ describe('PaletteSlot', () => {
 		const { getByTestId, component } = render(PaletteSlot, { color, disabled: true })
 		expect(getByTestId('__palette-slot-root__')).toBeDisabled()
 	})
+
+	it('selects slot', () => {
+		const color = '#ff0'
+		const { getByTestId, component } = render(PaletteSlot, { color, selected: true })
+		expect(getByTestId('__palette-slot-root__')).toHaveClass('selected')
+	})
 })


### PR DESCRIPTION
This PR aims at changing the way slots selection status is managed. Instead on relying on slot focus, we deal with a specific prop and apply a css class regarding its value.