### PR TITLE
Close tooltip after clicking content

### DIFF
--- a/src/Palette.svelte
+++ b/src/Palette.svelte
@@ -74,6 +74,7 @@
 							eventType: 'click',
 							callback: _onTooltipClick,
 							callbackParams: [index],
+							closeOnCallback: true
 						},
 					},
 					contentClassName: tooltipClassName,

--- a/src/__tests__/useTooltip.test.js
+++ b/src/__tests__/useTooltip.test.js
@@ -97,6 +97,18 @@ describe('useTooltip', () => {
 			await fireEvent.mouseEnter(target)
 			await fireEvent.click(template)
 			expect(contentAction.callback).toHaveBeenCalledWith(contentAction.callbackParams[0], expect.any(Event))
+			expect(template).toBeVisible()
+		})
+		
+		it('Closes tooltip after triggering callback', async () => {
+			action = useTooltip(target, options)
+			options.contentActions['*'].closeOnCallback = true
+			const contentAction = options.contentActions['*']
+			await fireEvent.mouseOver(target) // fireEvent.mouseEnter only works if mouseOver is triggered before
+			await fireEvent.mouseEnter(target)
+			await fireEvent.click(template)
+			expect(contentAction.callback).toHaveBeenCalledWith(contentAction.callbackParams[0], expect.any(Event))
+			expect(template).not.toBeVisible()
 		})
 
 		it('Triggers new callback on tooltip click after update', async () => {

--- a/src/useTooltip.js
+++ b/src/useTooltip.js
@@ -147,10 +147,15 @@ export class Tooltip {
 		this.#target.appendChild(this.#container)
 
 		if (this.#actions) {
-			Object.entries(this.#actions).forEach(([key, { eventType, callback, callbackParams }]) => {
+			Object.entries(this.#actions).forEach(([key, { eventType, callback, callbackParams, closeOnCallback }]) => {
 				const trigger = key === '*' ? this.#container : this.#container.querySelector(key)
 				if (trigger) {
-					const listener = (event) => callback?.apply(null, [...callbackParams, event])
+					const listener = (event) => {
+						callback?.apply(null, [...callbackParams, event])
+						if(closeOnCallback) {
+							this.#removeContainerFromTarget()
+						}
+					}
 					trigger.addEventListener(eventType, listener)
 					this.#events.push({ trigger, eventType, listener })
 				}


### PR DESCRIPTION
This PR forces the tooltip to close after clicking its content as the behaviour seems more natural this way.