### PR TITLE
Wait for tooltip content to exist or be added

### DIFF
--- a/src/__tests__/useTooltip.test.js
+++ b/src/__tests__/useTooltip.test.js
@@ -55,7 +55,9 @@ describe('useTooltip', () => {
 				action = useTooltip(target, options)
 				await fireEvent.mouseOver(target) // fireEvent.mouseEnter only works if mouseOver is triggered before
 				await fireEvent.mouseEnter(target)
+				console.log(document.body.innerHTML)
 				await fireEvent.mouseLeave(target)
+				console.log(document.body.innerHTML)
 				expect(template).not.toBeVisible()
 			})
 		})

--- a/src/useTooltip.js
+++ b/src/useTooltip.js
@@ -61,7 +61,7 @@ export class Tooltip {
 			Tooltip.#tooltip = document.createElement('div')
 
 			Tooltip.#observer = new DOMObserver()
-			Tooltip.#observer.wait(contentSelector, null, { events: [DOMObserver.ADD] }).then(({ node }) => {
+			Tooltip.#observer.wait(contentSelector, null, { events: [DOMObserver.EXIST, DOMObserver.ADD] }).then(({ node }) => {
 				const child = contentClone ? node.cloneNode(true) : node
 				Tooltip.#tooltip.appendChild(child)
 			})
@@ -75,7 +75,7 @@ export class Tooltip {
 		if (Tooltip.#isInitialized && contentSelector !== Tooltip.#contentSelector) {
 			Tooltip.#contentSelector = contentSelector
 
-			Tooltip.#observer.wait(contentSelector, null, { events: [DOMObserver.ADD] }).then(({ node }) => {
+			Tooltip.#observer.wait(contentSelector, null, { events: [DOMObserver.EXIST, DOMObserver.ADD] }).then(({ node }) => {
 				Tooltip.#tooltip.innerHTML = ''
 				const child = contentClone ? node.cloneNode(true) : node
 				Tooltip.#tooltip.appendChild(child)


### PR DESCRIPTION
This PR observes both existence and adding of the deletion tooltip content depending on the context. That fix the build issue since it allows tests to run successfully.