### PR TITLE
feat: Add TypeScript support

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,9 @@
 		".": {
 			"types": "./dist/index.d.ts",
 			"svelte": "./dist/index.js"
+		},
+		"./types": {
+			"types": "./dist/types.d.ts"
 		}
 	},
 	"engines": {

--- a/src/lib/components/Palette.svelte
+++ b/src/lib/components/Palette.svelte
@@ -16,6 +16,53 @@
 
 	import useDeletion from './useDeletion'
 
+	/**
+	 * @typedef {import('../types').ColorValue} ColorValue
+	 * @typedef {import('../types').ColorsProp} ColorsProp
+	 * @typedef {import('../types').DeletionMode} DeletionMode
+	 * @typedef {import('../types').InputType} InputType
+	 * @typedef {import('../types').Transition} Transition
+	 * @typedef {import('../types').SelectEventArgs} SelectEventArgs
+	 * @typedef {import('../types').HeaderSnippetProps} HeaderSnippetProps
+	 * @typedef {import('../types').EdgeSlotSnippetProps} EdgeSlotSnippetProps
+	 * @typedef {import('../types').SlotSnippetProps} SlotSnippetProps
+	 * @typedef {import('../types').InputSnippetProps} InputSnippetProps
+	 * @typedef {import('../types').ToolsSnippetProps} ToolsSnippetProps
+	 * @typedef {import('../types').SettingsSnippetProps} SettingsSnippetProps
+	 */
+
+	/**
+	 * @typedef {Object} Props
+	 * @property {ColorsProp | null} [colors] Colors to display, or a promise resolving to them. Accepts color strings, color objects or color groups.
+	 * @property {ColorValue | null} [selectedColor] Selected color. Supports `bind:selectedColor`.
+	 * @property {boolean} [isCompact] Whether the palette is displayed in compact mode.
+	 * @property {number[]} [compactColorIndices] Indices picked from `colors` when in compact mode.
+	 * @property {boolean} [allowDuplicates] Whether duplicate colors are allowed.
+	 * @property {DeletionMode} [deletionMode] Slot deletion mode.
+	 * @property {string | null} [tooltipClassName] Class name applied to the deletion tooltip.
+	 * @property {string | null} [tooltipContentSelector] Selector of the deletion tooltip content.
+	 * @property {boolean} [showTransparentSlot] Whether to display a transparent slot at the start of the list.
+	 * @property {number} [maxColors] Maximum number of slots. Set to `-1` for no limit.
+	 * @property {boolean} [showInput] Whether to display the color input within the footer.
+	 * @property {InputType} [inputType] Type of the color input.
+	 * @property {number} [numColumns] Number of grid columns. Set to `0` to display slots on a single row.
+	 * @property {number} [maxColumns] Maximum number of columns when `numColumns` is `0`. Set to `0` for no limit.
+	 * @property {Transition | null} [transition] Animation applied when a slot is rendered.
+	 * @property {(args: SelectEventArgs) => void} [onselect] Called whenever a color is selected.
+	 * @property {string} [class] Class name applied to the root element.
+	 * @property {import('svelte').Snippet<[HeaderSnippetProps]>} [header] Replaces the header.
+	 * @property {import('svelte').Snippet<[EdgeSlotSnippetProps]>} [beforeSlot] Rendered before the color slots.
+	 * @property {import('svelte').Snippet} [transparentSlot] Replaces the transparent slot.
+	 * @property {import('svelte').Snippet<[SlotSnippetProps]>} [slot] Replaces the default color slots.
+	 * @property {import('svelte').Snippet<[EdgeSlotSnippetProps]>} [afterSlot] Rendered after the color slots.
+	 * @property {import('svelte').Snippet} [loader] Replaces the loader shown while colors resolve.
+	 * @property {import('svelte').Snippet<[HeaderSnippetProps]>} [footer] Replaces the footer.
+	 * @property {import('svelte').Snippet<[InputSnippetProps]>} [input] Replaces the footer input.
+	 * @property {import('svelte').Snippet<[ToolsSnippetProps]>} [tools] Replaces the tools panel.
+	 * @property {import('svelte').Snippet<[SettingsSnippetProps]>} [settings] Replaces the settings panel content.
+	 */
+
+	/** @type {Props} */
 	let {
 		colors = null,
 		selectedColor = $bindable(null),

--- a/src/lib/components/PaletteCompactToggleButton.svelte
+++ b/src/lib/components/PaletteCompactToggleButton.svelte
@@ -2,6 +2,13 @@
 	import { COMPACT, ENLARGE } from '../enums/PaletteIcon'
 	import PaletteIconButton from './PaletteIconButton.svelte'
 
+	/**
+	 * @typedef {Object} Props
+	 * @property {boolean} [isCompact] Whether the palette is currently compact.
+	 * @property {(event: MouseEvent) => void} [onclick] Called when the button is clicked.
+	 */
+
+	/** @type {Props & Record<string, any>} */
 	let { isCompact = false, onclick = undefined, ...restProps } = $props()
 </script>
 

--- a/src/lib/components/PaletteCompactToggleButton.svelte
+++ b/src/lib/components/PaletteCompactToggleButton.svelte
@@ -8,7 +8,7 @@
 	 * @property {(event: MouseEvent) => void} [onclick] Called when the button is clicked.
 	 */
 
-	/** @type {Props & Record<string, any>} */
+	/** @type {Props & Omit<import('svelte/elements').HTMLButtonAttributes, keyof Props>} */
 	let { isCompact = false, onclick = undefined, ...restProps } = $props()
 </script>
 

--- a/src/lib/components/PaletteEyeDropperButton.svelte
+++ b/src/lib/components/PaletteEyeDropperButton.svelte
@@ -14,7 +14,7 @@
 	 * @property {(args: ErrorEventArgs) => void} [onerror] Called when the eye dropper fails or is dismissed.
 	 */
 
-	/** @type {Props & Record<string, any>} */
+	/** @type {Props & Omit<import('svelte/elements').HTMLButtonAttributes, keyof Props>} */
 	let { onadd = undefined, onerror = undefined, ...restProps } = $props()
 
 	const _onClick = async () => {

--- a/src/lib/components/PaletteEyeDropperButton.svelte
+++ b/src/lib/components/PaletteEyeDropperButton.svelte
@@ -3,6 +3,18 @@
 	import PaletteIconButton from './PaletteIconButton.svelte'
 	import { normalizeColor } from '../utils/utils.js'
 
+	/**
+	 * @typedef {import('../types').AddEventArgs} AddEventArgs
+	 * @typedef {import('../types').ErrorEventArgs} ErrorEventArgs
+	 */
+
+	/**
+	 * @typedef {Object} Props
+	 * @property {(args: AddEventArgs) => void} [onadd] Called when a color is picked with the eye dropper.
+	 * @property {(args: ErrorEventArgs) => void} [onerror] Called when the eye dropper fails or is dismissed.
+	 */
+
+	/** @type {Props & Record<string, any>} */
 	let { onadd = undefined, onerror = undefined, ...restProps } = $props()
 
 	const _onClick = async () => {

--- a/src/lib/components/PaletteIconButton.svelte
+++ b/src/lib/components/PaletteIconButton.svelte
@@ -8,6 +8,19 @@
 	import TrashIcon from './icons/TrashIcon.svelte'
 	import SettingsIcon from './icons/SettingsIcon.svelte'
 
+	/**
+	 * @typedef {import('../types').PaletteIconName} PaletteIconName
+	 */
+
+	/**
+	 * @typedef {Object} Props
+	 * @property {PaletteIconName | null} [icon] Icon to render.
+	 * @property {boolean} [isActive] Whether the button is in its active state.
+	 * @property {string} [class] Class name applied to the button.
+	 * @property {(event: MouseEvent) => void} [onclick] Called when the button is clicked.
+	 */
+
+	/** @type {Props & Record<string, any>} */
 	let { icon = null, isActive = false, class: className = '', onclick, ...restProps } = $props()
 
 	const ICONS = {

--- a/src/lib/components/PaletteIconButton.svelte
+++ b/src/lib/components/PaletteIconButton.svelte
@@ -20,7 +20,7 @@
 	 * @property {(event: MouseEvent) => void} [onclick] Called when the button is clicked.
 	 */
 
-	/** @type {Props & Record<string, any>} */
+	/** @type {Props & Omit<import('svelte/elements').HTMLButtonAttributes, keyof Props>} */
 	let { icon = null, isActive = false, class: className = '', onclick, ...restProps } = $props()
 
 	const ICONS = {

--- a/src/lib/components/PaletteInput.svelte
+++ b/src/lib/components/PaletteInput.svelte
@@ -9,6 +9,21 @@
 
 	import { COLOR_REGEX, isColorValid } from '../utils/utils'
 
+	/**
+	 * @typedef {import('../types').ColorValue} ColorValue
+	 * @typedef {import('../types').InputType} InputType
+	 * @typedef {import('../types').AddEventArgs} AddEventArgs
+	 */
+
+	/**
+	 * @typedef {Object} Props
+	 * @property {ColorValue | null} [color] The color pre-filled in the input.
+	 * @property {InputType} [inputType] Type of the input.
+	 * @property {(args: AddEventArgs) => void} [onadd] Called when a color is submitted.
+	 * @property {string} [class] Class name applied to the root element.
+	 */
+
+	/** @type {Props} */
 	let { color: colorProp = null, inputType = 'text', onadd = undefined, class: className = '' } = $props()
 
 	let color = $state(untrack(() => colorProp?.replace(COLOR_REGEX, '#$1') || ''))

--- a/src/lib/components/PaletteSettingsButton.svelte
+++ b/src/lib/components/PaletteSettingsButton.svelte
@@ -3,6 +3,12 @@
 
 	import PaletteIconButton from './PaletteIconButton.svelte'
 
+	/**
+	 * @typedef {Object} Props
+	 * @property {(event: MouseEvent) => void} [onclick] Called when the button is clicked.
+	 */
+
+	/** @type {Props & Record<string, any>} */
 	let { onclick = undefined, ...restProps } = $props()
 </script>
 

--- a/src/lib/components/PaletteSettingsButton.svelte
+++ b/src/lib/components/PaletteSettingsButton.svelte
@@ -8,7 +8,7 @@
 	 * @property {(event: MouseEvent) => void} [onclick] Called when the button is clicked.
 	 */
 
-	/** @type {Props & Record<string, any>} */
+	/** @type {Props & Omit<import('svelte/elements').HTMLButtonAttributes, keyof Props>} */
 	let { onclick = undefined, ...restProps } = $props()
 </script>
 

--- a/src/lib/components/PaletteSettingsPanel.svelte
+++ b/src/lib/components/PaletteSettingsPanel.svelte
@@ -37,6 +37,14 @@
 </script>
 
 <script>
+	/**
+	 * @typedef {Object} Props
+	 * @property {string} [target] Selector or element the panel is portalled into.
+	 * @property {boolean} [isVisible] Whether the panel is visible.
+	 * @property {import('svelte').Snippet} [children] Panel content.
+	 */
+
+	/** @type {Props} */
 	let { target = 'body', isVisible = false, children } = $props()
 </script>
 

--- a/src/lib/components/PaletteSlot.svelte
+++ b/src/lib/components/PaletteSlot.svelte
@@ -14,7 +14,7 @@
 	 * @property {(args: SelectEventArgs) => void} [onselect] Called when the slot is clicked.
 	 */
 
-	/** @type {Props & Record<string, any>} */
+	/** @type {Props & Omit<import('svelte/elements').HTMLButtonAttributes, keyof Props>} */
 	let {
 		color = null,
 		selected = false,

--- a/src/lib/components/PaletteSlot.svelte
+++ b/src/lib/components/PaletteSlot.svelte
@@ -1,4 +1,20 @@
 <script>
+	/**
+	 * @typedef {import('../types').ColorValue} ColorValue
+	 * @typedef {import('../types').Transition} Transition
+	 * @typedef {import('../types').SelectEventArgs} SelectEventArgs
+	 */
+
+	/**
+	 * @typedef {Object} Props
+	 * @property {ColorValue | null} [color] The color value of the slot.
+	 * @property {boolean} [selected] Whether the slot is selected.
+	 * @property {boolean} [disabled] Whether the slot is disabled.
+	 * @property {Transition | null} [transition] Animation applied when the slot is rendered.
+	 * @property {(args: SelectEventArgs) => void} [onselect] Called when the slot is clicked.
+	 */
+
+	/** @type {Props & Record<string, any>} */
 	let {
 		color = null,
 		selected = false,

--- a/src/lib/components/PaletteTools.svelte
+++ b/src/lib/components/PaletteTools.svelte
@@ -4,6 +4,18 @@
 	import PaletteCompactToggleButton from './PaletteCompactToggleButton.svelte'
 	import PaletteSettingsButton from './PaletteSettingsButton.svelte'
 
+	/**
+	 * @typedef {import('../types').PaletteToolName} PaletteToolName
+	 * @typedef {import('../types').ToolSelectEventArgs} ToolSelectEventArgs
+	 */
+
+	/**
+	 * @typedef {Object} Props
+	 * @property {PaletteToolName[]} [tools] Tools to display.
+	 * @property {(args: ToolSelectEventArgs) => void} [onselect] Called when a tool is selected.
+	 */
+
+	/** @type {Props} */
 	let { tools = [], onselect = undefined } = $props()
 
 	const TOOL_BUTTONS = {

--- a/src/lib/components/PaletteTrashButton.svelte
+++ b/src/lib/components/PaletteTrashButton.svelte
@@ -1,6 +1,14 @@
 <script>
 	import TrashIcon from './icons/TrashIcon.svelte'
 
+	/**
+	 * @typedef {Object} Props
+	 * @property {boolean} [isActive] Whether the button is in its active state.
+	 * @property {string} [class] Class name applied to the button.
+	 * @property {(event: MouseEvent) => void} [onclick] Called when the button is clicked.
+	 */
+
+	/** @type {Props & Record<string, any>} */
 	let { isActive = false, class: className = '', onclick = undefined, ...restProps } = $props()
 </script>
 

--- a/src/lib/components/PaletteTrashButton.svelte
+++ b/src/lib/components/PaletteTrashButton.svelte
@@ -8,7 +8,7 @@
 	 * @property {(event: MouseEvent) => void} [onclick] Called when the button is clicked.
 	 */
 
-	/** @type {Props & Record<string, any>} */
+	/** @type {Props & Omit<import('svelte/elements').HTMLButtonAttributes, keyof Props>} */
 	let { isActive = false, class: className = '', onclick = undefined, ...restProps } = $props()
 </script>
 

--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -1,0 +1,173 @@
+import type { TransitionConfig } from 'svelte/transition'
+
+/**
+ * A single color value. Any CSS color string is accepted, typically a hex value such as `#865C54`.
+ */
+export type ColorValue = string
+
+/**
+ * A color expressed as an object, allowing an optional display name to be associated with the value.
+ */
+export interface ColorObject {
+	/** Optional display name for the color. */
+	name?: string
+	/** The color value (any CSS color string, typically a hex value). */
+	value: ColorValue
+}
+
+/**
+ * A color passed to the palette, either as a bare value or as a {@link ColorObject}.
+ */
+export type ColorInput = ColorValue | ColorObject
+
+/**
+ * A named collection of colors. Passing an array of groups displays the palette as labelled sections.
+ */
+export interface ColorGroup {
+	/** Optional label displayed above the group. */
+	name?: string
+	/** Colors belonging to the group. */
+	colors: ColorInput[]
+}
+
+/**
+ * The resolved value accepted by the `colors` prop: either a flat list of colors or a list of groups.
+ */
+export type Colors = ColorInput[] | ColorGroup[]
+
+/**
+ * The value accepted by the `colors` prop, synchronously or as a promise to be resolved.
+ */
+export type ColorsProp = Colors | Promise<Colors>
+
+/**
+ * Slot appearance animation, mirroring Svelte's `in:`/`out:` directive API.
+ */
+export interface Transition {
+	/** Transition function (a Svelte-exported transition or a custom one). */
+	fn: (node: Element, args?: any) => TransitionConfig
+	/** Parameters passed to the transition function. */
+	args?: any
+}
+
+/**
+ * Available slot deletion modes. Enums are exported as `NONE`, `TOOLTIP` and `DROP`.
+ */
+export type DeletionMode = 'none' | 'tooltip' | 'drop'
+
+/**
+ * Available palette tools. Enums are exported as `COMPACT` and `SETTINGS`.
+ */
+export type PaletteToolName = 'compact' | 'settings'
+
+/**
+ * Icons rendered by `PaletteIconButton`.
+ */
+export type PaletteIconName = 'compact' | 'enlarge' | 'eyeDropper' | 'plus' | 'settings' | 'trash'
+
+/**
+ * Accepted types for the color input. Any other value falls back to `"text"`.
+ */
+export type InputType = 'text' | 'color'
+
+/**
+ * Argument passed to the `onselect` callback when a color is picked.
+ */
+export interface SelectEventArgs {
+	/** The selected color value, or `null` when the transparent slot is selected. */
+	color: ColorValue | null
+}
+
+/**
+ * Argument passed to the `onadd` callback when a color is added through the input or the eye dropper.
+ */
+export interface AddEventArgs {
+	/** The color value being added. */
+	color: ColorValue
+}
+
+/**
+ * Argument passed to the `onerror` callback when the eye dropper fails or is dismissed.
+ */
+export interface ErrorEventArgs {
+	/** The error thrown by the EyeDropper API. */
+	error: unknown
+}
+
+/**
+ * Argument passed to the tools `onselect` callback when a tool is activated.
+ */
+export interface ToolSelectEventArgs {
+	/** The activated tool. */
+	tool: PaletteToolName
+}
+
+/**
+ * Properties passed to the `header` and `footer` snippets.
+ */
+export interface HeaderSnippetProps {
+	/** The currently selected color, or `null` when none is selected. */
+	selectedColor: ColorValue | null
+}
+
+/**
+ * Properties passed to the `beforeSlot` and `afterSlot` snippets.
+ */
+export interface EdgeSlotSnippetProps {
+	/** The currently selected color, or `null` when none is selected. */
+	selectedColor: ColorValue | null
+	/** The transition applied to the slots, if any. */
+	transition: Transition | null
+	/** Whether the palette is displayed in compact mode. */
+	isCompact: boolean
+}
+
+/**
+ * Properties passed to the `slot` snippet that replaces the default color slots.
+ */
+export interface SlotSnippetProps {
+	/** Index of the color within its list (or group). */
+	index: number
+	/** The color value of the slot. */
+	color: ColorValue
+	/** The color name, when the color was provided as an object. */
+	colorName: string | null
+	/** The group name, only provided when the colors are grouped. */
+	groupName?: string
+	/** The currently selected color, or `null` when none is selected. */
+	selectedColor: ColorValue | null
+	/** The transition applied to the slot, if any. */
+	transition: Transition | null
+	/** Whether the palette is displayed in compact mode. */
+	isCompact: boolean
+}
+
+/**
+ * Properties passed to the `input` snippet that replaces the default color input.
+ */
+export interface InputSnippetProps {
+	/** The currently selected color, or `null` when none is selected. */
+	selectedColor: ColorValue | null
+	/** The resolved input type. */
+	inputType: InputType
+}
+
+/**
+ * Properties passed to the `tools` snippet that replaces the default tools panel.
+ */
+export interface ToolsSnippetProps {
+	/** Indices used to build the compact palette. */
+	compactColorIndices: number[]
+	/** Whether the palette is displayed in compact mode. */
+	isCompact: boolean
+	/** Activates a tool by name (use the exported `PaletteTool` enums). */
+	onSelect: (tool: PaletteToolName) => void
+}
+
+/**
+ * Properties passed to the `settings` snippet that replaces the default settings panel content.
+ */
+export interface SettingsSnippetProps {
+	/** Closes the settings panel. */
+	onClose: () => void
+}

--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -130,8 +130,8 @@ export interface SlotSnippetProps {
 	index: number
 	/** The color value of the slot. */
 	color: ColorValue
-	/** The color name, when the color was provided as an object. */
-	colorName: string | null
+	/** The color name, when the color was provided as an object; `undefined` for bare color values. */
+	colorName?: string
 	/** The group name, only provided when the colors are grouped. */
 	groupName?: string
 	/** The currently selected color, or `null` when none is selected. */

--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -160,7 +160,7 @@ export interface ToolsSnippetProps {
 	compactColorIndices: number[]
 	/** Whether the palette is displayed in compact mode. */
 	isCompact: boolean
-	/** Activates a tool by name (use the exported `PaletteTool` enums). */
+	/** Activates a tool by name (use the exported `COMPACT` and `SETTINGS` constants). */
 	onSelect: (tool: PaletteToolName) => void
 }
 


### PR DESCRIPTION
## Summary

The package already emitted `.d.ts` files, but because the components are plain JS with no type annotations, `svelte-package` inferred `any` for every non-primitive prop (`colors`, `selectedColor`, `onselect`, all snippets, …). Consumers got a declaration file with no real IntelliSense or type safety. This PR makes the package genuinely typed: real, documented types for every public component prop, callback and snippet, plus an importable set of shared domain types.

## Changes

- Add `src/lib/types.d.ts` with the shared public types: `ColorValue`, `ColorObject`, `ColorInput`, `ColorGroup`, `Colors`, `ColorsProp` (incl. the `Promise` variants), `Transition`, `DeletionMode`, `PaletteToolName`, `PaletteIconName`, `InputType`, the event-argument types and the snippet-parameter types.
- Annotate every public component's `$props()` with JSDoc (`@typedef Props`) referencing those shared types, so `svelte-package` now emits real declarations (props, bindable `selectedColor`, typed callbacks, and `Snippet<[...]>` snippet parameters). Components that forward `...restProps` keep arbitrary HTML-attribute support via `& Record<string, any>`.
- Expose the shared types publicly through a new `./types` subpath export, so consumers can `import type { ColorGroup, Transition } from '@untemps/svelte-palette/types'`.

## Test plan

- [x] `yarn test:ci` — all tests pass (runtime is unchanged; this is a types-only change)
- [x] `yarn build` — `svelte-package` emits typed declarations and `publint` reports "All good!"
- [x] `yarn lint` — Prettier clean
- [x] Inspected the generated `dist/**/*.d.ts`: every prop now carries a real type (no stray `any`)
- [x] Type-checked from a consumer's perspective with `tsc` (valid usages compile; invalid `deletionMode`/`selectedColor`/`inputType`/`ColorGroup` values are rejected; `ComponentProps<typeof Palette>` resolves; `restProps` still accept extra HTML attributes)
- [x] `yarn dev` — demo routes render (HTTP 200)

## Notes

No runtime or public-API changes. Existing TypeScript consumers that previously received `any`-typed props will now get real type checking; code that does not follow the documented contract may surface new (correct) type errors.

Closes #54