### PR TITLE
fix: Highlight the slot matching the selected color

### DIFF
--- a/src/lib/components/Palette.svelte
+++ b/src/lib/components/Palette.svelte
@@ -278,7 +278,7 @@
 									{:else}
 										<PaletteSlot
 											color={color.value}
-											selected={(color as unknown) === selectedColor}
+											selected={color.value === selectedColor}
 											{transition}
 											onselect={_onSlotSelect}
 										/>
@@ -330,7 +330,7 @@
 						{:else}
 							<PaletteSlot
 								color={color.value}
-								selected={(color as unknown) === selectedColor}
+								selected={color.value === selectedColor}
 								{transition}
 								onselect={_onSlotSelect}
 							/>

--- a/src/lib/components/__tests__/Palette.test.ts
+++ b/src/lib/components/__tests__/Palette.test.ts
@@ -29,6 +29,18 @@ test('Displays as many color slots as set', async () => {
 	expect(cells).toHaveLength(colors.length)
 })
 
+test('Marks the slot matching selectedColor as selected', async () => {
+	const colors = ['#ff0', '#0ff', '#f0f']
+	setup(Palette, {
+		props: { colors, selectedColor: '#0ff' },
+	})
+
+	const slots = await screen.findAllByTestId('__palette-slot__')
+	expect(slots[0]).not.toHaveClass('selected')
+	expect(slots[1]).toHaveClass('selected')
+	expect(slots[2]).not.toHaveClass('selected')
+})
+
 test('Displays as many color slots as set in async mode', async () => {
 	let cells = null
 	const colors = Promise.resolve(['#ff0', '#0ff', '#f0f'])


### PR DESCRIPTION
## Bug

In `Palette.svelte`, the slot loops compared the **normalized color object** (`{ value, name }`, produced by `calculateColors`) directly to `selectedColor` (a **string**):

```svelte
<PaletteSlot ... selected={color === selectedColor} />
```

An object is never `===` a string, so the comparison was **always `false`** — grid slots never rendered as `selected`. Surfaced by `svelte-check` during the TypeScript port (#214): *"This comparison appears to be unintentional… `NormalizedColor` and `string | null` have no overlap."*

## Fix

Compare `color.value` (the actual color string) to `selectedColor`:

```svelte
<PaletteSlot ... selected={color.value === selectedColor} />
```

Both the grouped and flat slot loops are fixed. Added a regression test (`Marks the slot matching selectedColor as selected`) — verified it fails on the old code and passes on the fix.

## Notes

- **Stacked on #214** (base: `refactor/54-typescript-port`). #214 keeps this as a pure port (behind a cast); this PR is the actual behavior fix. Merge #214 first, then this.
- `yarn run check`, `yarn test:ci` (299 tests) and `yarn lint` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
