### PR TITLE
fix: Make the compact toggle and resolver inputs fully reactive

### DIFF
--- a/src/lib/components/Palette.svelte
+++ b/src/lib/components/Palette.svelte
@@ -198,11 +198,14 @@
 		/**
 		 * Snapshot every remaining input synchronously: reads inside the `.then()` callback happen in a
 		 * microtask, outside Svelte's dependency-tracking window, so they would never re-trigger this
-		 * effect. Only these snapshots may be used below the promise.
+		 * effect. Only these snapshots may be used below the promise. `compactColorIndices` is copied by
+		 * value: spreading reads its elements synchronously, so in-place mutations of a bound `$state`
+		 * array are tracked too, and the copy freezes the indices against mutations that land before an
+		 * async `colors` source resolves.
 		 */
 		const _colorParams = {
 			isCompact: _isCompact,
-			compactColorIndices,
+			compactColorIndices: [...(compactColorIndices ?? [])],
 			allowDuplicates,
 			maxColors,
 		}

--- a/src/lib/components/Palette.svelte
+++ b/src/lib/components/Palette.svelte
@@ -379,8 +379,9 @@
 	 * A compact deletion mutates the underlying full list, not the extracted subset `_colors`: it removes the
 	 * mapped color, re-indexes `compactColorIndices` onto the shrunk list, recomputes the view and writes the
 	 * full list back through `bind:colors`. The `ondelete` `index` is the removed color's position in that
-	 * full list. Guarded against a view index that maps to nothing (e.g. a runtime compact toggle whose
-	 * `_colors` was never re-extracted).
+	 * full list. The mismatch guard is defense in depth: the resolver re-extracts `_colors` whenever
+	 * `_isCompact` or `compactColorIndices` change, so a view index only maps to nothing if the rendered
+	 * subset drifted from `_fullColors` (e.g. through a stale async resolution).
 	 */
 	const _removeCompactColor = (index: number) => {
 		const target = _compactPicked()[index]
@@ -437,6 +438,15 @@
 
 	const _onDelete = (index: number) => _removeColor(index)
 
+	/**
+	 * Flipping `_isCompact` is all a toggle needs: the resolver `$effect` tracks it and recomputes
+	 * `_colors` and `_numColumns` together from the current `colors` source, so the column count is
+	 * derived (transparent slot included) rather than remembered across toggles.
+	 */
+	const _toggleCompact = () => {
+		_isCompact = !_isCompact
+	}
+
 	const _onToolSelect = (args: ToolSelectEventArgs | PaletteToolName) => {
 		const tool = typeof args === 'string' ? args : args.tool
 		switch (tool) {
@@ -444,16 +454,12 @@
 				_isSettingsOn = true
 				break
 			case COMPACT:
-				_isCompact = !_isCompact
-				_numColumns = _isCompact ? compactColorIndices.length : _numColumns
+				_toggleCompact()
 				break
 		}
 	}
 
-	const _onExpand = () => {
-		_isCompact = !_isCompact
-		_numColumns = _isCompact ? compactColorIndices.length : _numColumns
-	}
+	const _onExpand = () => _toggleCompact()
 
 	const _onSettingsClose = () => {
 		_isSettingsOn = false

--- a/src/lib/components/Palette.svelte
+++ b/src/lib/components/Palette.svelte
@@ -195,6 +195,23 @@
 		const _source = colors
 		const _numCols = numColumns
 		const _maxCols = maxColumns
+		/**
+		 * Snapshot every remaining input synchronously: reads inside the `.then()` callback happen in a
+		 * microtask, outside Svelte's dependency-tracking window, so they would never re-trigger this
+		 * effect. Only these snapshots may be used below the promise.
+		 */
+		const _colorParams = {
+			isCompact: _isCompact,
+			compactColorIndices,
+			allowDuplicates,
+			maxColors,
+		}
+		const _columnParams = {
+			..._colorParams,
+			showTransparentSlot,
+			numColumns: _numCols,
+			maxColumns: _maxCols,
+		}
 		if (untrack(() => _skipColorsSync)) {
 			_skipColorsSync = false
 			return
@@ -204,8 +221,8 @@
 				_focusedIndex = null
 				if (isColorGroups(results)) {
 					const newColorGroups = calculateColorGroups(results, {
-						allowDuplicates,
-						maxColors,
+						allowDuplicates: _colorParams.allowDuplicates,
+						maxColors: _colorParams.maxColors,
 					})
 					_colorGroups = newColorGroups
 					_colors = null
@@ -213,22 +230,11 @@
 					const maxGroupLength = newColorGroups.reduce((max, g) => Math.max(max, g.colors.length), 0)
 					_numColumns = calculateNumColumns(maxGroupLength, { numColumns: _numCols })
 				} else {
-					const newColors = calculateColors(results, {
-						isCompact: _isCompact,
-						compactColorIndices,
-						allowDuplicates,
-						maxColors,
-					})
+					const newColors = calculateColors(results, _colorParams)
 					_colors = newColors
 					_colorGroups = null
 					_fullColors = transformColors(Array.isArray(results) ? results : [])
-					_numColumns = calculateNumColumns(newColors.length, {
-						isCompact: _isCompact,
-						compactColorIndices,
-						showTransparentSlot,
-						numColumns: _numCols,
-						maxColumns: _maxCols,
-					})
+					_numColumns = calculateNumColumns(newColors.length, _columnParams)
 				}
 			}
 		})

--- a/src/lib/components/Palette.svelte
+++ b/src/lib/components/Palette.svelte
@@ -176,10 +176,41 @@
 	/**
 	 * One-shot guard set by the write-back helpers (`_syncColors`/`_syncColorGroups`) so the resolver
 	 * `$effect` skips the component's own mutation of the bound `colors` instead of re-normalizing it.
-	 * It is consumed (reset to `false`) on the next effect run. Being one-shot, reassigning `colors`
-	 * synchronously from within `onadd`/`ondelete` is dropped until the next external change.
+	 * It is consumed (reset to `false`) on the next effect run, which compares the current view params
+	 * against `_syncedViewParams` — the values captured when the guard was armed — and only skips while
+	 * they still match, so a view input mutated from within `onadd`/`ondelete` (e.g. flipping
+	 * `isCompact`) is recomputed instead of dropped. Being one-shot, reassigning `colors` itself
+	 * synchronously from within `onadd`/`ondelete` is still dropped until the next external change.
 	 */
 	let _skipColorsSync = $state(false)
+	let _syncedViewParams: ReturnType<typeof _viewParams> | null = null
+
+	/**
+	 * Reads every input that shapes the rendered view — synchronously, so a `$effect` calling it
+	 * tracks them all. `compactColorIndices` is copied by value: spreading reads its elements
+	 * synchronously, so in-place mutations of a bound `$state` array are tracked too, and the copy
+	 * freezes the indices against mutations that land before an async `colors` source resolves.
+	 */
+	const _viewParams = () => ({
+		isCompact: _isCompact,
+		compactColorIndices: [...(compactColorIndices ?? [])],
+		allowDuplicates,
+		maxColors,
+		showTransparentSlot,
+		numColumns,
+		maxColumns,
+	})
+
+	const _sameViewParams = (a: ReturnType<typeof _viewParams> | null, b: ReturnType<typeof _viewParams>): boolean =>
+		a != null &&
+		a.isCompact === b.isCompact &&
+		a.allowDuplicates === b.allowDuplicates &&
+		a.maxColors === b.maxColors &&
+		a.showTransparentSlot === b.showTransparentSlot &&
+		a.numColumns === b.numColumns &&
+		a.maxColumns === b.maxColumns &&
+		a.compactColorIndices.length === b.compactColorIndices.length &&
+		a.compactColorIndices.every((index, i) => index === b.compactColorIndices[i])
 
 	$effect(() => {
 		_isCompact = isCompact
@@ -193,51 +224,42 @@
 
 	$effect(() => {
 		const _source = colors
-		const _numCols = numColumns
-		const _maxCols = maxColumns
 		/**
 		 * Snapshot every remaining input synchronously: reads inside the `.then()` callback happen in a
 		 * microtask, outside Svelte's dependency-tracking window, so they would never re-trigger this
-		 * effect. Only these snapshots may be used below the promise. `compactColorIndices` is copied by
-		 * value: spreading reads its elements synchronously, so in-place mutations of a bound `$state`
-		 * array are tracked too, and the copy freezes the indices against mutations that land before an
-		 * async `colors` source resolves.
+		 * effect. Only this snapshot may be used below the promise.
 		 */
-		const _colorParams = {
-			isCompact: _isCompact,
-			compactColorIndices: [...(compactColorIndices ?? [])],
-			allowDuplicates,
-			maxColors,
-		}
-		const _columnParams = {
-			..._colorParams,
-			showTransparentSlot,
-			numColumns: _numCols,
-			maxColumns: _maxCols,
-		}
+		const _params = _viewParams()
 		if (untrack(() => _skipColorsSync)) {
 			_skipColorsSync = false
-			return
+			/**
+			 * Skip only while the view still matches what the write-back rendered: when `onadd`/`ondelete`
+			 * mutates a view input (e.g. flips `isCompact`) in the same flush as the write-back, fall
+			 * through and recompute from the just-written-back source instead of dropping the change.
+			 */
+			if (_sameViewParams(_syncedViewParams, _params)) {
+				return
+			}
 		}
 		Promise.resolve(_source).then((results) => {
 			if (!!results) {
 				_focusedIndex = null
 				if (isColorGroups(results)) {
 					const newColorGroups = calculateColorGroups(results, {
-						allowDuplicates: _colorParams.allowDuplicates,
-						maxColors: _colorParams.maxColors,
+						allowDuplicates: _params.allowDuplicates,
+						maxColors: _params.maxColors,
 					})
 					_colorGroups = newColorGroups
 					_colors = null
 					_fullColors = null
 					const maxGroupLength = newColorGroups.reduce((max, g) => Math.max(max, g.colors.length), 0)
-					_numColumns = calculateNumColumns(maxGroupLength, { numColumns: _numCols })
+					_numColumns = calculateNumColumns(maxGroupLength, { numColumns: _params.numColumns })
 				} else {
-					const newColors = calculateColors(results, _colorParams)
+					const newColors = calculateColors(results, _params)
 					_colors = newColors
 					_colorGroups = null
 					_fullColors = transformColors(Array.isArray(results) ? results : [])
-					_numColumns = calculateNumColumns(newColors.length, _columnParams)
+					_numColumns = calculateNumColumns(newColors.length, _params)
 				}
 			}
 		})
@@ -312,11 +334,13 @@
 	const _syncColors = (nextColors: NormalizedColor[]) => {
 		_fullColors = nextColors
 		_skipColorsSync = true
+		_syncedViewParams = _viewParams()
 		colors = nextColors
 	}
 
 	const _syncColorGroups = (nextColorGroups: NormalizedColorGroup[]) => {
 		_skipColorsSync = true
+		_syncedViewParams = _viewParams()
 		colors = nextColorGroups
 	}
 

--- a/src/lib/components/__tests__/Palette.test.ts
+++ b/src/lib/components/__tests__/Palette.test.ts
@@ -463,6 +463,21 @@ test('Re-extracts the compact subset when compactColorIndices change', async () 
 	})
 })
 
+test('Re-extracts the compact subset when compactColorIndices are mutated in place', async () => {
+	const colors = ['#ff0', '#0ff', '#f0f']
+
+	const { component } = setup(PaletteReactive, {
+		props: { initialColors: colors, initialIsCompact: true, initialCompactColorIndices: [0, 1] },
+	})
+
+	const slots = await screen.findAllByTestId('__palette-slot__')
+	expect(slots).toHaveLength(2)
+
+	component.appendCompactColorIndex(2)
+
+	await waitFor(() => expect(screen.getAllByTestId('__palette-slot__')).toHaveLength(3))
+})
+
 test('Does not expose a main landmark on the root', async () => {
 	const colors = ['#ff0', '#0ff', '#f0f']
 	setup(Palette, { colors })

--- a/src/lib/components/__tests__/Palette.test.ts
+++ b/src/lib/components/__tests__/Palette.test.ts
@@ -1,11 +1,11 @@
 import { afterEach, expect, test, vi } from 'vitest'
 import { cleanup, render, screen, waitFor } from '@testing-library/svelte/svelte5'
 import userEvent from '@testing-library/user-event'
-import { standby } from '@untemps/utils/async/standby'
 import { createRawSnippet } from 'svelte'
 
 import Palette from '../Palette.svelte'
 import PaletteBind from './PaletteBind.test.svelte'
+import PaletteReactive from './PaletteReactive.test.svelte'
 
 import { TOOLTIP, DROP } from '../../enums/PaletteDeletionMode'
 
@@ -210,6 +210,9 @@ test('Expands palette when compact toggle button is clicked', async () => {
 		props: { colors, compactColorIndices, isCompact: true },
 	})
 
+	const cells = await screen.findAllByTestId('__palette-cell__')
+	expect(cells).toHaveLength(2)
+
 	const toggleButton = await screen.findByTestId('__palette-compact-toggle-button__')
 	expect(toggleButton).toBeInTheDocument()
 
@@ -217,6 +220,26 @@ test('Expands palette when compact toggle button is clicked', async () => {
 
 	const content = document.querySelector('.palette__content')
 	await waitFor(() => expect(content).not.toHaveClass('palette__content--compact'))
+	await waitFor(() => expect(screen.getAllByTestId('__palette-cell__')).toHaveLength(3))
+})
+
+test('Extracts the compact subset when the palette is collapsed at runtime', async () => {
+	const colors = ['#ff0', '#0ff', '#f0f']
+	const compactColorIndices = [0, 1]
+
+	const { user } = setup(Palette, {
+		props: { colors, compactColorIndices },
+	})
+
+	const cells = await screen.findAllByTestId('__palette-cell__')
+	expect(cells).toHaveLength(3)
+
+	const toggleButton = await screen.findByTestId('__palette-compact-toggle-button__')
+	await user.click(toggleButton)
+
+	const content = document.querySelector('.palette__content')
+	await waitFor(() => expect(content).toHaveClass('palette__content--compact'))
+	await waitFor(() => expect(screen.getAllByTestId('__palette-cell__')).toHaveLength(2))
 })
 
 test('Closes settings panel when onClose is called', async () => {
@@ -344,27 +367,75 @@ test('Updates num-columns when numColumns changes to 0', async () => {
 	await waitFor(() => expect(section.getAttribute('style')).toContain('--num-columns: 25'))
 })
 
+// The reactivity tests below drive the palette through PaletteReactive, a parent wrapper holding
+// each prop in its own $state. Testing Library's `rerender` funnels every prop through a single
+// signal, so re-passing `colors` re-triggers the resolver and would mask a prop left untracked.
 test('Removes duplicates when updating allowDuplicates value', async () => {
-	let slots = null
 	const colors = ['#ff0', '#0ff', '#f0f', '#f0f', '#f0f']
 
-	const { rerender } = setup(Palette, {
-		colors,
-		allowDuplicates: true,
+	const { component } = setup(PaletteReactive, {
+		props: { initialColors: colors, initialAllowDuplicates: true },
 	})
 
-	slots = await screen.findAllByTestId('__palette-slot__')
+	const slots = await screen.findAllByTestId('__palette-slot__')
 	expect(slots).toHaveLength(colors.length)
 
-	rerender({
-		colors,
-		allowDuplicates: false,
+	component.setAllowDuplicates(false)
+
+	await waitFor(() => expect(screen.getAllByTestId('__palette-slot__')).toHaveLength(3))
+})
+
+test('Applies maxColors when it changes from a reactive parent', async () => {
+	const colors = ['#ff0', '#0ff', '#f0f', '#00f']
+
+	const { component } = setup(PaletteReactive, {
+		props: { initialColors: colors, initialMaxColors: 4 },
 	})
 
-	await standby(1000)
+	const cells = await screen.findAllByTestId('__palette-cell__')
+	expect(cells).toHaveLength(4)
 
-	slots = await screen.findAllByTestId('__palette-slot__')
-	expect(slots).toHaveLength(3)
+	component.setMaxColors(2)
+
+	await waitFor(() => expect(screen.getAllByTestId('__palette-cell__')).toHaveLength(2))
+})
+
+test('Applies the compact subset when isCompact changes from a reactive parent', async () => {
+	const colors = ['#ff0', '#0ff', '#f0f']
+
+	const { component } = setup(PaletteReactive, {
+		props: { initialColors: colors, initialCompactColorIndices: [0, 1] },
+	})
+
+	const cells = await screen.findAllByTestId('__palette-cell__')
+	expect(cells).toHaveLength(3)
+
+	component.setIsCompact(true)
+
+	await waitFor(() => expect(screen.getAllByTestId('__palette-cell__')).toHaveLength(2))
+
+	component.setIsCompact(false)
+
+	await waitFor(() => expect(screen.getAllByTestId('__palette-cell__')).toHaveLength(3))
+})
+
+test('Re-extracts the compact subset when compactColorIndices change', async () => {
+	const colors = ['#ff0', '#0ff', '#f0f']
+
+	const { component } = setup(PaletteReactive, {
+		props: { initialColors: colors, initialIsCompact: true, initialCompactColorIndices: [0, 1] },
+	})
+
+	const slots = await screen.findAllByTestId('__palette-slot__')
+	expect(slots).toHaveLength(2)
+
+	component.setCompactColorIndices([2])
+
+	await waitFor(() => {
+		const remaining = screen.getAllByTestId('__palette-slot__')
+		expect(remaining).toHaveLength(1)
+		expect(remaining[0]).toHaveAttribute('aria-label', '#f0f')
+	})
 })
 
 test('Does not expose a main landmark on the root', async () => {
@@ -1448,7 +1519,7 @@ test('Deletes the mapped color when compactColorIndices are unsorted', async () 
 	expect(cells).toHaveLength(1)
 })
 
-test('Falls back to a local removal without ondelete when compact is toggled at runtime', async () => {
+test('Propagates a compact deletion to the full list when compact is toggled at runtime', async () => {
 	const onDelete = vi.fn()
 	const colors = ['#a00', '#0b0', '#00c', '#dd0', '#0ee']
 
@@ -1467,14 +1538,21 @@ test('Falls back to a local removal without ondelete when compact is toggled at 
 	const toggle = await screen.findByTestId('__palette-compact-toggle-button__')
 	await user.click(toggle)
 
-	cells = await screen.findAllByTestId('__palette-cell__')
+	await waitFor(() => expect(screen.getAllByTestId('__palette-cell__')).toHaveLength(2))
+
+	cells = screen.getAllByTestId('__palette-cell__')
 	await user.hover(cells[0])
 	const trash = await screen.findByTestId('__trash-icon__')
 	await user.click(trash)
 
-	expect(onDelete).not.toHaveBeenCalled()
+	expect(onDelete).toHaveBeenCalledWith({
+		color: '#0b0',
+		index: 1,
+		colors: [{ value: '#a00' }, { value: '#00c' }, { value: '#dd0' }, { value: '#0ee' }],
+	})
+
 	cells = await screen.findAllByTestId('__palette-cell__')
-	expect(cells).toHaveLength(4)
+	expect(cells).toHaveLength(1)
 })
 
 test('Reflects an add and a delete back through bind:colors', async () => {

--- a/src/lib/components/__tests__/Palette.test.ts
+++ b/src/lib/components/__tests__/Palette.test.ts
@@ -478,6 +478,33 @@ test('Re-extracts the compact subset when compactColorIndices are mutated in pla
 	await waitFor(() => expect(screen.getAllByTestId('__palette-slot__')).toHaveLength(3))
 })
 
+test('Applies an isCompact change made inside ondelete alongside the write-back', async () => {
+	const colors = ['#a00', '#0b0', '#00c', '#dd0']
+
+	let palette: { setIsCompact: (value: boolean) => void } | undefined
+	const { component, user } = setup(PaletteReactive, {
+		props: {
+			initialColors: colors,
+			initialCompactColorIndices: [0, 1],
+			deletionMode: TOOLTIP,
+			ondelete: () => palette?.setIsCompact(true),
+		},
+	})
+	palette = component
+
+	const cells = await screen.findAllByTestId('__palette-cell__')
+	expect(cells).toHaveLength(4)
+
+	await user.hover(cells[3])
+	const trash = await screen.findByTestId('__trash-icon__')
+	await user.click(trash)
+
+	const content = document.querySelector('.palette__content')
+	await waitFor(() => expect(content).toHaveClass('palette__content--compact'))
+	await waitFor(() => expect(screen.getAllByTestId('__palette-cell__')).toHaveLength(2))
+	await waitFor(() => expect(content.getAttribute('style')).toContain('--num-columns: 2'))
+})
+
 test('Does not expose a main landmark on the root', async () => {
 	const colors = ['#ff0', '#0ff', '#f0f']
 	setup(Palette, { colors })

--- a/src/lib/components/__tests__/Palette.test.ts
+++ b/src/lib/components/__tests__/Palette.test.ts
@@ -213,14 +213,17 @@ test('Expands palette when compact toggle button is clicked', async () => {
 	const cells = await screen.findAllByTestId('__palette-cell__')
 	expect(cells).toHaveLength(2)
 
+	const content = document.querySelector('.palette__content')
+	await waitFor(() => expect(content.getAttribute('style')).toContain('--num-columns: 2'))
+
 	const toggleButton = await screen.findByTestId('__palette-compact-toggle-button__')
 	expect(toggleButton).toBeInTheDocument()
 
 	await user.click(toggleButton)
 
-	const content = document.querySelector('.palette__content')
 	await waitFor(() => expect(content).not.toHaveClass('palette__content--compact'))
 	await waitFor(() => expect(screen.getAllByTestId('__palette-cell__')).toHaveLength(3))
+	await waitFor(() => expect(content.getAttribute('style')).toContain('--num-columns: 5'))
 })
 
 test('Extracts the compact subset when the palette is collapsed at runtime', async () => {
@@ -234,12 +237,34 @@ test('Extracts the compact subset when the palette is collapsed at runtime', asy
 	const cells = await screen.findAllByTestId('__palette-cell__')
 	expect(cells).toHaveLength(3)
 
+	const content = document.querySelector('.palette__content')
+	await waitFor(() => expect(content.getAttribute('style')).toContain('--num-columns: 5'))
+
+	const toggleButton = await screen.findByTestId('__palette-compact-toggle-button__')
+	await user.click(toggleButton)
+
+	await waitFor(() => expect(content).toHaveClass('palette__content--compact'))
+	await waitFor(() => expect(screen.getAllByTestId('__palette-cell__')).toHaveLength(2))
+	await waitFor(() => expect(content.getAttribute('style')).toContain('--num-columns: 2'))
+})
+
+test('Accounts for the transparent slot in the compact column count when collapsed at runtime', async () => {
+	const colors = ['#ff0', '#0ff', '#f0f']
+	const compactColorIndices = [0, 1]
+
+	const { user } = setup(Palette, {
+		props: { colors, compactColorIndices, showTransparentSlot: true },
+	})
+
+	await screen.findAllByTestId('__palette-cell__')
+
 	const toggleButton = await screen.findByTestId('__palette-compact-toggle-button__')
 	await user.click(toggleButton)
 
 	const content = document.querySelector('.palette__content')
 	await waitFor(() => expect(content).toHaveClass('palette__content--compact'))
-	await waitFor(() => expect(screen.getAllByTestId('__palette-cell__')).toHaveLength(2))
+	await waitFor(() => expect(screen.getAllByTestId('__palette-cell__')).toHaveLength(3))
+	await waitFor(() => expect(content.getAttribute('style')).toContain('--num-columns: 3'))
 })
 
 test('Closes settings panel when onClose is called', async () => {

--- a/src/lib/components/__tests__/Palette.test.ts
+++ b/src/lib/components/__tests__/Palette.test.ts
@@ -478,6 +478,54 @@ test('Re-extracts the compact subset when compactColorIndices are mutated in pla
 	await waitFor(() => expect(screen.getAllByTestId('__palette-slot__')).toHaveLength(3))
 })
 
+test('Recomputes the compact column count when showTransparentSlot changes', async () => {
+	const colors = ['#ff0', '#0ff', '#f0f']
+
+	const { component } = setup(PaletteReactive, {
+		props: { initialColors: colors, initialIsCompact: true, initialCompactColorIndices: [0, 1] },
+	})
+
+	const cells = await screen.findAllByTestId('__palette-cell__')
+	expect(cells).toHaveLength(2)
+
+	const content = document.querySelector('.palette__content')
+	await waitFor(() => expect(content.getAttribute('style')).toContain('--num-columns: 2'))
+
+	component.setShowTransparentSlot(true)
+
+	await waitFor(() => expect(screen.getAllByTestId('__palette-cell__')).toHaveLength(3))
+	await waitFor(() => expect(content.getAttribute('style')).toContain('--num-columns: 3'))
+})
+
+test('Falls back to a local removal when the rendered subset drifts from the full list', async () => {
+	const onDelete = vi.fn()
+
+	const { component, user } = setup(PaletteReactive, {
+		props: {
+			initialColors: ['#a00', '#0b0', '#00c'],
+			initialIsCompact: true,
+			initialCompactColorIndices: [0, 1],
+			deletionMode: TOOLTIP,
+			ondelete: onDelete,
+		},
+	})
+
+	const cells = await screen.findAllByTestId('__palette-cell__')
+	expect(cells).toHaveLength(2)
+
+	// Freeze the resolver on a never-resolving source, then desync the indices: the rendered
+	// subset can no longer be re-extracted and stops matching _compactPicked's mapping.
+	component.setColors(new Promise(() => {}))
+	component.setCompactColorIndices([2])
+
+	await user.hover(cells[0])
+	const trash = await screen.findByTestId('__trash-icon__')
+	await user.click(trash)
+
+	expect(onDelete).not.toHaveBeenCalled()
+	await waitFor(() => expect(screen.getAllByTestId('__palette-cell__')).toHaveLength(1))
+})
+
 test('Applies an isCompact change made inside ondelete alongside the write-back', async () => {
 	const colors = ['#a00', '#0b0', '#00c', '#dd0']
 

--- a/src/lib/components/__tests__/PaletteBind.test.svelte
+++ b/src/lib/components/__tests__/PaletteBind.test.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import { untrack } from 'svelte'
+
 	import Palette from '../Palette.svelte'
 
 	import { TOOLTIP } from '../../enums/PaletteDeletionMode'
@@ -11,8 +13,8 @@
 		initialCompactColorIndices = [],
 	}: { initialColors: ColorsProp; isCompact?: boolean; initialCompactColorIndices?: number[] } = $props()
 
-	let colors = $state<ColorsProp | null>(initialColors)
-	let compactColorIndices = $state<number[]>(initialCompactColorIndices)
+	let colors = $state<ColorsProp | null>(untrack(() => initialColors))
+	let compactColorIndices = $state<number[]>(untrack(() => initialCompactColorIndices))
 </script>
 
 <div data-testid="__bound-colors__">{JSON.stringify(colors)}</div>

--- a/src/lib/components/__tests__/PaletteReactive.test.svelte
+++ b/src/lib/components/__tests__/PaletteReactive.test.svelte
@@ -31,6 +31,9 @@
 
 	export const setIsCompact = (value: boolean) => (isCompact = value)
 	export const setCompactColorIndices = (value: number[]) => (compactColorIndices = value)
+	export const appendCompactColorIndex = (value: number) => {
+		compactColorIndices.push(value)
+	}
 	export const setAllowDuplicates = (value: boolean) => (allowDuplicates = value)
 	export const setMaxColors = (value: number) => (maxColors = value)
 	export const setShowTransparentSlot = (value: boolean) => (showTransparentSlot = value)

--- a/src/lib/components/__tests__/PaletteReactive.test.svelte
+++ b/src/lib/components/__tests__/PaletteReactive.test.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import { untrack } from 'svelte'
+
 	import Palette from '../Palette.svelte'
 
 	import { NONE } from '../../enums/PaletteDeletionMode'
@@ -27,14 +29,15 @@
 		ondelete?: (args: DeleteEventArgs) => void
 	} = $props()
 
-	let colors = $state<ColorsProp | null>(initialColors)
-	let isCompact = $state<boolean>(initialIsCompact)
-	let compactColorIndices = $state<number[]>(initialCompactColorIndices)
-	let allowDuplicates = $state<boolean>(initialAllowDuplicates)
-	let maxColors = $state<number>(initialMaxColors)
-	let showTransparentSlot = $state<boolean>(initialShowTransparentSlot)
-	let numColumns = $state<number>(initialNumColumns)
+	let colors = $state<ColorsProp | null>(untrack(() => initialColors))
+	let isCompact = $state<boolean>(untrack(() => initialIsCompact))
+	let compactColorIndices = $state<number[]>(untrack(() => initialCompactColorIndices))
+	let allowDuplicates = $state<boolean>(untrack(() => initialAllowDuplicates))
+	let maxColors = $state<number>(untrack(() => initialMaxColors))
+	let showTransparentSlot = $state<boolean>(untrack(() => initialShowTransparentSlot))
+	let numColumns = $state<number>(untrack(() => initialNumColumns))
 
+	export const setColors = (value: ColorsProp | null) => (colors = value)
 	export const setIsCompact = (value: boolean) => (isCompact = value)
 	export const setCompactColorIndices = (value: number[]) => (compactColorIndices = value)
 	export const appendCompactColorIndex = (value: number) => {

--- a/src/lib/components/__tests__/PaletteReactive.test.svelte
+++ b/src/lib/components/__tests__/PaletteReactive.test.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
 	import Palette from '../Palette.svelte'
 
-	import type { ColorsProp } from '../../types'
+	import { NONE } from '../../enums/PaletteDeletionMode'
+
+	import type { ColorsProp, DeleteEventArgs, DeletionMode } from '../../types'
 
 	let {
 		initialColors,
@@ -11,6 +13,8 @@
 		initialMaxColors = 30,
 		initialShowTransparentSlot = false,
 		initialNumColumns = 5,
+		deletionMode = NONE,
+		ondelete = undefined,
 	}: {
 		initialColors: ColorsProp
 		initialIsCompact?: boolean
@@ -19,6 +23,8 @@
 		initialMaxColors?: number
 		initialShowTransparentSlot?: boolean
 		initialNumColumns?: number
+		deletionMode?: DeletionMode
+		ondelete?: (args: DeleteEventArgs) => void
 	} = $props()
 
 	let colors = $state<ColorsProp | null>(initialColors)
@@ -47,4 +53,6 @@
 	{maxColors}
 	{showTransparentSlot}
 	{numColumns}
+	{deletionMode}
+	{ondelete}
 />

--- a/src/lib/components/__tests__/PaletteReactive.test.svelte
+++ b/src/lib/components/__tests__/PaletteReactive.test.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+	import Palette from '../Palette.svelte'
+
+	import type { ColorsProp } from '../../types'
+
+	let {
+		initialColors,
+		initialIsCompact = false,
+		initialCompactColorIndices = [],
+		initialAllowDuplicates = false,
+		initialMaxColors = 30,
+		initialShowTransparentSlot = false,
+		initialNumColumns = 5,
+	}: {
+		initialColors: ColorsProp
+		initialIsCompact?: boolean
+		initialCompactColorIndices?: number[]
+		initialAllowDuplicates?: boolean
+		initialMaxColors?: number
+		initialShowTransparentSlot?: boolean
+		initialNumColumns?: number
+	} = $props()
+
+	let colors = $state<ColorsProp | null>(initialColors)
+	let isCompact = $state<boolean>(initialIsCompact)
+	let compactColorIndices = $state<number[]>(initialCompactColorIndices)
+	let allowDuplicates = $state<boolean>(initialAllowDuplicates)
+	let maxColors = $state<number>(initialMaxColors)
+	let showTransparentSlot = $state<boolean>(initialShowTransparentSlot)
+	let numColumns = $state<number>(initialNumColumns)
+
+	export const setIsCompact = (value: boolean) => (isCompact = value)
+	export const setCompactColorIndices = (value: number[]) => (compactColorIndices = value)
+	export const setAllowDuplicates = (value: boolean) => (allowDuplicates = value)
+	export const setMaxColors = (value: number) => (maxColors = value)
+	export const setShowTransparentSlot = (value: boolean) => (showTransparentSlot = value)
+</script>
+
+<Palette
+	bind:colors
+	{isCompact}
+	{compactColorIndices}
+	{allowDuplicates}
+	{maxColors}
+	{showTransparentSlot}
+	{numColumns}
+/>


### PR DESCRIPTION
## Summary

The color-resolving `$effect` read most of its inputs inside its `.then()` callback — a microtask outside Svelte 5's synchronous dependency-tracking window — so `isCompact`, `compactColorIndices`, `allowDuplicates`, `maxColors` and `showTransparentSlot` never re-triggered it: toggling compact mode flipped the CSS class but kept rendering the previous subset, and prop changes from a reactive parent were silently ignored (#174). On top of that, both compact toggle handlers overwrote `_numColumns` with `compactColorIndices.length` on collapse and no-op'd on expand, so the expanded palette kept the narrow compact grid (#168).

The resolver now snapshots every view input synchronously through a shared `_viewParams` helper (copying `compactColorIndices` by value so in-place mutations of a bound `$state` array are tracked too), and a toggle just flips `_isCompact` — `_colors` and `_numColumns` are recomputed together from a single tracked source. The one-shot write-back guard now skips only while the view params still match the values captured when it was armed, so an `isCompact`/prop change made inside `onadd`/`ondelete` is recomputed instead of swallowed.

## Changes

- Snapshot all resolver inputs synchronously before the promise; use only the snapshot below it
- Copy `compactColorIndices` by value in the snapshot to track in-place mutations and freeze it against pre-resolution changes
- Drop the manual `_numColumns` writes from both compact toggle handlers; share a single `_toggleCompact` helper
- Arm the write-back guard with a `_syncedViewParams` snapshot and fall through to a recompute when the view params changed in the same flush
- Re-document the `_removeCompactColor` mismatch guard as defense in depth
- New `PaletteReactive` test wrapper holding each prop in its own `$state` (Testing Library's `rerender` funnels all props through a single signal, masking untracked reads); reactivity regression tests for `isCompact`, `compactColorIndices` (reassigned and mutated in place), `allowDuplicates`, `maxColors`, `showTransparentSlot`; `--num-columns` assertions across both toggle directions; coverage for the mismatch-guard fallback; wrapper `$state` initializers untracked to clear `state_referenced_locally` warnings

## Test plan

- [ ] `yarn test:ci` — 755 tests green (the 8 new/rewritten reactivity tests were verified to fail on the unfixed tree)
- [ ] `yarn build`, `yarn lint`, `yarn check` — green
- [ ] In `yarn dev` → example 1: collapse the palette via the tools button and expand it back — the subset (4 slots) and full list (23 slots) swap correctly and the grid restores its `numColumns` setting; `maxColors`/`allowDuplicates`/`numColumns` changes from the settings panel apply live

## Notes

- Behavior change (intended, documented): after a runtime compact toggle, deleting a compact slot now propagates to the full bound list and fires `ondelete`, instead of silently removing the slot only locally
- Out of scope, tracked separately: stale async resolution ordering (#170), `colors` deep-proxy in-place mutations (pre-existing reference-only tracking), triple test collection (#185)

Closes #174
Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)