### PR TITLE
fix: Scope drop deletion area to the owning palette

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
 		"@untemps/utils": "^3.0.0"
 	},
 	"peerDependencies": {
-		"svelte": "^5.0.0"
+		"svelte": "^5.20.0"
 	},
 	"release": {
 		"branches": [

--- a/src/lib/components/Palette.svelte
+++ b/src/lib/components/Palette.svelte
@@ -1,7 +1,3 @@
-<script module lang="ts">
-	let _instanceCount = 0
-</script>
-
 <script lang="ts">
 	import { tick, untrack } from 'svelte'
 
@@ -121,7 +117,7 @@
 		settings = undefined,
 	}: Props = $props()
 
-	const _paletteId = `palette-${_instanceCount++}`
+	const _paletteId = $props.id()
 
 	let _colors = $state<NormalizedColor[] | null>(null)
 	let _fullColors = $state<NormalizedColor[] | null>(null)
@@ -545,7 +541,13 @@
 	}
 </script>
 
-<div id={_paletteId} class="palette {className}" data-testid="__palette__" data-palette style:--focusColor={focusColor}>
+<div
+	data-palette-id={_paletteId}
+	class="palette {className}"
+	data-testid="__palette__"
+	data-palette
+	style:--focusColor={focusColor}
+>
 	<section class="palette__content" class:palette__content--compact={_isCompact} style="--num-columns: {_numColumns}">
 		{#if !_isCompact}
 			{@render header?.({ selectedColor })}
@@ -585,7 +587,7 @@
 									role="presentation"
 									use:useDeletion={{
 										deletionMode,
-										areaSelector: `#${_paletteId}`,
+										areaSelector: `[data-palette-id="${_paletteId}"]`,
 										onDelete: () => _removeGroupColor(groupIndex, colorIndex),
 										tooltipContentSelector,
 										tooltipClassName,
@@ -666,7 +668,7 @@
 							role="presentation"
 							use:useDeletion={{
 								deletionMode,
-								areaSelector: `#${_paletteId}`,
+								areaSelector: `[data-palette-id="${_paletteId}"]`,
 								onDelete: () => _onDelete(index),
 								tooltipContentSelector,
 								tooltipClassName,

--- a/src/lib/components/Palette.svelte
+++ b/src/lib/components/Palette.svelte
@@ -1,8 +1,4 @@
 <script module lang="ts">
-	// Monotonic per-instance counter used to build a unique id for each palette root. The drop
-	// deletion area is resolved through a document-wide `document.querySelector`, so every mounted
-	// palette needs its own selector — otherwise all instances would test "inside vs. outside"
-	// against the first `.palette` element on the page.
 	let _instanceCount = 0
 </script>
 
@@ -56,78 +52,37 @@
 	} from '../types'
 
 	interface Props {
-		/** Colors to display, or a promise resolving to them. Accepts color strings, color objects or color groups. */
 		colors?: ColorsProp | null
-		/** Selected color. Supports `bind:selectedColor`. */
 		selectedColor?: ColorValue | null
-		/** Whether the palette is displayed in compact mode. */
 		isCompact?: boolean
-		/** Indices picked from `colors` when in compact mode. Supports `bind:compactColorIndices`; re-indexed when a compact slot is deleted. */
 		compactColorIndices?: number[]
-		/** Whether duplicate colors are allowed. */
 		allowDuplicates?: boolean
-		/** Slot deletion mode. */
 		deletionMode?: DeletionMode
-		/** Class name applied to the deletion tooltip. */
 		tooltipClassName?: string | null
-		/** Selector of the deletion tooltip content. */
 		tooltipContentSelector?: string | null
-		/** Whether to display a transparent slot at the start of the list. */
 		showTransparentSlot?: boolean
-		/** Maximum number of slots. Set to `-1` for no limit. */
 		maxColors?: number
-		/** Whether to display the color input within the footer. */
 		showInput?: boolean
-		/** Type of the color input. */
 		inputType?: InputType
-		/** Number of grid columns. Set to `0` to display slots on a single row. */
 		numColumns?: number
-		/** Maximum number of columns when `numColumns` is `0`. Set to `0` for no limit. */
 		maxColumns?: number
-		/** Animation applied when a slot is rendered. */
 		transition?: Transition | null
-		/** Called whenever a color is selected. */
 		onselect?: (args: SelectEventArgs) => void
-		/** Called once a color has been added to the list through the input. */
 		onadd?: (args: AddEventArgs) => void
-		/** Called once a color has been removed from the list through the deletion gesture. */
 		ondelete?: (args: DeleteEventArgs) => void
-		/** Accessible name announced for the color slot listbox. */
 		label?: string
-		/**
-		 * Renders the slot grid as a purely visual display instead of a listbox:
-		 * drops the `listbox`/`option` roles, the roving tab stop and the arrow-key
-		 * navigation. Use it for decorative palettes that are not meant to be picked from.
-		 */
 		presentational?: boolean
-		/** Class name applied to the root element. */
 		class?: string
-		/**
-		 * Color of the focus outline on color slots, including custom `slot`/`transparentSlot` snippets
-		 * (applied through a `--focusColor` CSS variable set on the palette root, which those snippets
-		 * inherit and also receive as a `focusColor` argument). Defaults to `blue`; can also be set
-		 * through the `--focusColor` CSS variable directly.
-		 */
 		focusColor?: string
-		/** Replaces the header. */
 		header?: Snippet<[HeaderSnippetProps]>
-		/** Rendered before the color slots. */
 		beforeSlot?: Snippet<[EdgeSlotSnippetProps]>
-		/** Replaces the transparent slot. */
 		transparentSlot?: Snippet<[TransparentSlotSnippetProps]>
-		/** Replaces the default color slots. */
 		slot?: Snippet<[SlotSnippetProps]>
-		/** Rendered after the color slots. */
 		afterSlot?: Snippet<[EdgeSlotSnippetProps]>
-		/** Replaces the loader shown while colors resolve. */
 		loader?: Snippet
-		/** Replaces the footer. */
 		footer?: Snippet<[HeaderSnippetProps]>
-		/** Replaces the footer input. */
 		input?: Snippet<[InputSnippetProps]>
-		/** Replaces the tools panel. */
 		tools?: Snippet<[ToolsSnippetProps]>
-		/** Replaces the settings panel content. */
 		settings?: Snippet<[SettingsSnippetProps]>
 	}
 
@@ -166,18 +121,9 @@
 		settings = undefined,
 	}: Props = $props()
 
-	// Unique id for this palette root, threaded down to `useDeletion` as the drop area selector so
-	// each instance scopes deletion to its own root (see `_instanceCount` above).
 	const _paletteId = `palette-${_instanceCount++}`
 
 	let _colors = $state<NormalizedColor[] | null>(null)
-	/**
-	 * The full resolved and transformed flat list — before compact extraction, deduplication or capping —
-	 * that `compactColorIndices` index into. Retained so a compact-mode deletion can map a view index back
-	 * to the real color and write the shrunk full list back to the bound `colors`. Null in grouped mode.
-	 * Reassigned by `_syncColors` on every flat write-back (the written-back list becomes the new full
-	 * list), so a later runtime compact toggle never maps deletions against pre-mutation data.
-	 */
 	let _fullColors = $state<NormalizedColor[] | null>(null)
 	let _colorGroups = $state<NormalizedColorGroup[] | null>(null)
 	let _numColumns = $state(untrack(() => numColumns))
@@ -185,24 +131,9 @@
 	let _isCompact = $state(untrack(() => isCompact))
 	let _listboxEl = $state<HTMLElement | null>(null)
 	let _focusedIndex = $state<number | null>(null)
-	/**
-	 * One-shot guard set by the write-back helpers (`_syncColors`/`_syncColorGroups`) so the resolver
-	 * `$effect` skips the component's own mutation of the bound `colors` instead of re-normalizing it.
-	 * It is consumed (reset to `false`) on the next effect run, which compares the current view params
-	 * against `_syncedViewParams` — the values captured when the guard was armed — and only skips while
-	 * they still match, so a view input mutated from within `onadd`/`ondelete` (e.g. flipping
-	 * `isCompact`) is recomputed instead of dropped. Being one-shot, reassigning `colors` itself
-	 * synchronously from within `onadd`/`ondelete` is still dropped until the next external change.
-	 */
 	let _skipColorsSync = $state(false)
 	let _syncedViewParams: ReturnType<typeof _viewParams> | null = null
 
-	/**
-	 * Reads every input that shapes the rendered view — synchronously, so a `$effect` calling it
-	 * tracks them all. `compactColorIndices` is copied by value: spreading reads its elements
-	 * synchronously, so in-place mutations of a bound `$state` array are tracked too, and the copy
-	 * freezes the indices against mutations that land before an async `colors` source resolves.
-	 */
 	const _viewParams = () => ({
 		isCompact: _isCompact,
 		compactColorIndices: [...(compactColorIndices ?? [])],
@@ -236,19 +167,9 @@
 
 	$effect(() => {
 		const _source = colors
-		/**
-		 * Snapshot every remaining input synchronously: reads inside the `.then()` callback happen in a
-		 * microtask, outside Svelte's dependency-tracking window, so they would never re-trigger this
-		 * effect. Only this snapshot may be used below the promise.
-		 */
 		const _params = _viewParams()
 		if (untrack(() => _skipColorsSync)) {
 			_skipColorsSync = false
-			/**
-			 * Skip only while the view still matches what the write-back rendered: when `onadd`/`ondelete`
-			 * mutates a view input (e.g. flips `isCompact`) in the same flush as the write-back, fall
-			 * through and recompute from the just-written-back source instead of dropping the change.
-			 */
 			if (_sameViewParams(_syncedViewParams, _params)) {
 				return
 			}
@@ -333,9 +254,6 @@
 
 	const _optionRole = $derived(presentational ? undefined : 'option')
 
-	// Announce the keyboard deletion affordance on deletable options. Absent when deletion is off
-	// or the grid is presentational (no keydown handler), and never set on the transparent slot,
-	// which is not a deletable color. Mirrors the `Delete`/`Backspace` handling in `_deleteOption`.
 	const _deleteShortcut = $derived(!presentational && deletionMode !== NONE ? 'Delete Backspace' : undefined)
 
 	const _selectColor = (color: ColorValue | null) => {
@@ -395,12 +313,6 @@
 		}
 	}
 
-	/**
-	 * Replays `calculateColors`' compact pipeline (extract → dedupe → cap) while carrying each color's index
-	 * in `_fullColors`, so a compact view index maps back to the real full-list color unambiguously — even
-	 * when deduplication collapses same-valued slots (the first occurrence wins, matching the rendered
-	 * list). Mirrors the ordering in `calculateColors` exactly.
-	 */
 	const _compactPicked = (): { color: NormalizedColor; index: number }[] => {
 		const full = _fullColors ?? []
 		const indices = compactColorIndices ?? []
@@ -414,14 +326,6 @@
 		return picked
 	}
 
-	/**
-	 * A compact deletion mutates the underlying full list, not the extracted subset `_colors`: it removes the
-	 * mapped color, re-indexes `compactColorIndices` onto the shrunk list, recomputes the view and writes the
-	 * full list back through `bind:colors`. The `ondelete` `index` is the removed color's position in that
-	 * full list. The mismatch guard is defense in depth: the resolver re-extracts `_colors` whenever
-	 * `_isCompact` or `compactColorIndices` change, so a view index only maps to nothing if the rendered
-	 * subset drifted from `_fullColors` (e.g. through a stale async resolution).
-	 */
 	const _removeCompactColor = (index: number) => {
 		const target = _compactPicked()[index]
 		const rendered = (_colors ?? [])[index]
@@ -477,11 +381,6 @@
 
 	const _onDelete = (index: number) => _removeColor(index)
 
-	/**
-	 * Flipping `_isCompact` is all a toggle needs: the resolver `$effect` tracks it and recomputes
-	 * `_colors` and `_numColumns` together from the current `colors` source, so the column count is
-	 * derived (transparent slot included) rather than remembered across toggles.
-	 */
 	const _toggleCompact = () => {
 		_isCompact = !_isCompact
 	}
@@ -504,14 +403,9 @@
 		_isSettingsOn = false
 	}
 
-	// Cache the resolved option elements so arrow-key navigation does not re-query the DOM
-	// on every keystroke. The cache is dropped whenever the rendered option set can change.
 	let _cachedOptions: HTMLElement[] | null = null
 
 	$effect(() => {
-		// Track the state that drives which slots are rendered so the cache is invalidated.
-		// `selectedColor` is included because a custom `slot` may swap its focusable node
-		// when it becomes selected, which would otherwise leave detached nodes cached.
 		void _colors
 		void _colorGroups
 		void showTransparentSlot
@@ -562,8 +456,6 @@
 		return targetRow[Math.min(column, targetRow.length - 1)]
 	}
 
-	// Delete the color under the focused option, the keyboard counterpart of the pointer-only
-	// tooltip/drop deletion affordances. Focus stays on the neighbour that shifts into place.
 	const _deleteOption = async (from: number) => {
 		if (deletionMode === NONE) {
 			return
@@ -584,18 +476,14 @@
 		} else {
 			const colorIndex = from - (showTransparentSlot ? 1 : 0)
 			if (colorIndex < 0) {
-				// The leading transparent slot clears the selection; it is not a deletable color.
 				return
 			}
 			_onDelete(colorIndex)
 		}
-		// The option set has been replaced; drop the cache and move focus to the neighbour.
 		await tick()
 		_cachedOptions = null
 		const options = _getOptions()
 		if (options.length === 0) {
-			// Nothing left to focus: keep focus on the listbox container rather than
-			// letting it fall back to <body> now that the deleted option is gone.
 			_focusedIndex = null
 			_listboxEl?.focus()
 			return

--- a/src/lib/components/Palette.svelte
+++ b/src/lib/components/Palette.svelte
@@ -1,3 +1,11 @@
+<script module lang="ts">
+	// Monotonic per-instance counter used to build a unique id for each palette root. The drop
+	// deletion area is resolved through a document-wide `document.querySelector`, so every mounted
+	// palette needs its own selector — otherwise all instances would test "inside vs. outside"
+	// against the first `.palette` element on the page.
+	let _instanceCount = 0
+</script>
+
 <script lang="ts">
 	import { tick, untrack } from 'svelte'
 
@@ -157,6 +165,10 @@
 		tools = undefined,
 		settings = undefined,
 	}: Props = $props()
+
+	// Unique id for this palette root, threaded down to `useDeletion` as the drop area selector so
+	// each instance scopes deletion to its own root (see `_instanceCount` above).
+	const _paletteId = `palette-${_instanceCount++}`
 
 	let _colors = $state<NormalizedColor[] | null>(null)
 	/**
@@ -645,7 +657,7 @@
 	}
 </script>
 
-<div class="palette {className}" data-testid="__palette__" data-palette style:--focusColor={focusColor}>
+<div id={_paletteId} class="palette {className}" data-testid="__palette__" data-palette style:--focusColor={focusColor}>
 	<section class="palette__content" class:palette__content--compact={_isCompact} style="--num-columns: {_numColumns}">
 		{#if !_isCompact}
 			{@render header?.({ selectedColor })}
@@ -685,6 +697,7 @@
 									role="presentation"
 									use:useDeletion={{
 										deletionMode,
+										areaSelector: `#${_paletteId}`,
 										onDelete: () => _removeGroupColor(groupIndex, colorIndex),
 										tooltipContentSelector,
 										tooltipClassName,
@@ -765,6 +778,7 @@
 							role="presentation"
 							use:useDeletion={{
 								deletionMode,
+								areaSelector: `#${_paletteId}`,
 								onDelete: () => _onDelete(index),
 								tooltipContentSelector,
 								tooltipClassName,

--- a/src/lib/components/__tests__/Palette.test.ts
+++ b/src/lib/components/__tests__/Palette.test.ts
@@ -18,7 +18,6 @@ const setup = (component: Parameters<typeof render>[0], options?: Parameters<typ
 
 afterEach(() => cleanup())
 
-// Minimal DOMRect stand-in: the drop library only reads left/right/top/bottom to test overlap.
 const boundingRect = (left: number, top: number, right: number, bottom: number) =>
 	({ left, top, right, bottom, width: right - left, height: bottom - top }) as DOMRect
 
@@ -138,15 +137,12 @@ test('Scopes the drop deletion area to the owning palette when several are mount
 
 	await screen.findAllByTestId('__palette-slot__')
 
-	// Two non-overlapping palette areas on the page.
 	const [rootA, rootB] = screen.getAllByTestId('__palette__')
 	rootA.getBoundingClientRect = () => boundingRect(0, 0, 100, 100)
 	rootB.getBoundingClientRect = () => boundingRect(200, 200, 300, 300)
 
 	const cellB = containerB.querySelector('[data-testid="__palette-cell__"]') as HTMLElement
 
-	// Drop a swatch of palette B inside palette B's own area (but outside palette A's). Scoped to its
-	// own root this is a no-op; resolving the area to the first `.palette` would delete it (the bug).
 	await user.pointer({ keys: '[MouseLeft>]', target: cellB })
 	const drag = document.querySelector('#drag') as HTMLElement
 	drag.getBoundingClientRect = () => boundingRect(250, 250, 260, 260)
@@ -170,7 +166,6 @@ test('Deletes a swatch dropped outside its own palette even over another palette
 
 	const cellB = containerB.querySelector('[data-testid="__palette-cell__"]') as HTMLElement
 
-	// Drop over palette A's area — that is outside palette B's own root, so the swatch must be deleted.
 	await user.pointer({ keys: '[MouseLeft>]', target: cellB })
 	const drag = document.querySelector('#drag') as HTMLElement
 	drag.getBoundingClientRect = () => boundingRect(50, 50, 60, 60)
@@ -446,9 +441,6 @@ test('Updates num-columns when numColumns changes to 0', async () => {
 	await waitFor(() => expect(section.getAttribute('style')).toContain('--num-columns: 25'))
 })
 
-// The reactivity tests below drive the palette through PaletteReactive, a parent wrapper holding
-// each prop in its own $state. Testing Library's `rerender` funnels every prop through a single
-// signal, so re-passing `colors` re-triggers the resolver and would mask a prop left untracked.
 test('Removes duplicates when updating allowDuplicates value', async () => {
 	const colors = ['#ff0', '#0ff', '#f0f', '#f0f', '#f0f']
 
@@ -567,8 +559,6 @@ test('Falls back to a local removal when the rendered subset drifts from the ful
 	const cells = await screen.findAllByTestId('__palette-cell__')
 	expect(cells).toHaveLength(2)
 
-	// Freeze the resolver on a never-resolving source, then desync the indices: the rendered
-	// subset can no longer be re-extracted and stops matching _compactPicked's mapping.
 	component.setColors(new Promise(() => {}))
 	component.setCompactColorIndices([2])
 

--- a/src/lib/components/__tests__/Palette.test.ts
+++ b/src/lib/components/__tests__/Palette.test.ts
@@ -18,6 +18,10 @@ const setup = (component: Parameters<typeof render>[0], options?: Parameters<typ
 
 afterEach(() => cleanup())
 
+// Minimal DOMRect stand-in: the drop library only reads left/right/top/bottom to test overlap.
+const boundingRect = (left: number, top: number, right: number, bottom: number) =>
+	({ left, top, right, bottom, width: right - left, height: bottom - top }) as DOMRect
+
 test('Displays as many color slots as set', async () => {
 	let cells = null
 	const colors = ['#ff0', '#0ff', '#f0f']
@@ -123,6 +127,56 @@ test('Deletes slot if deletionMode is set to "drop"', async () => {
 	await user.pointer('[/MouseLeft]')
 
 	expect(cell).not.toBeInTheDocument()
+})
+
+test('Scopes the drop deletion area to the owning palette when several are mounted', async () => {
+	const colorsA = ['#ff0', '#0ff', '#f0f']
+	const colorsB = ['#111', '#222', '#333']
+
+	const { user } = setup(Palette, { props: { colors: colorsA, deletionMode: DROP } })
+	const { container: containerB } = render(Palette, { props: { colors: colorsB, deletionMode: DROP } })
+
+	await screen.findAllByTestId('__palette-slot__')
+
+	// Two non-overlapping palette areas on the page.
+	const [rootA, rootB] = screen.getAllByTestId('__palette__')
+	rootA.getBoundingClientRect = () => boundingRect(0, 0, 100, 100)
+	rootB.getBoundingClientRect = () => boundingRect(200, 200, 300, 300)
+
+	const cellB = containerB.querySelector('[data-testid="__palette-cell__"]') as HTMLElement
+
+	// Drop a swatch of palette B inside palette B's own area (but outside palette A's). Scoped to its
+	// own root this is a no-op; resolving the area to the first `.palette` would delete it (the bug).
+	await user.pointer({ keys: '[MouseLeft>]', target: cellB })
+	const drag = document.querySelector('#drag') as HTMLElement
+	drag.getBoundingClientRect = () => boundingRect(250, 250, 260, 260)
+	await user.pointer('[/MouseLeft]')
+
+	expect(cellB).toBeInTheDocument()
+})
+
+test('Deletes a swatch dropped outside its own palette even over another palette', async () => {
+	const colorsA = ['#ff0', '#0ff', '#f0f']
+	const colorsB = ['#111', '#222', '#333']
+
+	const { user } = setup(Palette, { props: { colors: colorsA, deletionMode: DROP } })
+	const { container: containerB } = render(Palette, { props: { colors: colorsB, deletionMode: DROP } })
+
+	await screen.findAllByTestId('__palette-slot__')
+
+	const [rootA, rootB] = screen.getAllByTestId('__palette__')
+	rootA.getBoundingClientRect = () => boundingRect(0, 0, 100, 100)
+	rootB.getBoundingClientRect = () => boundingRect(200, 200, 300, 300)
+
+	const cellB = containerB.querySelector('[data-testid="__palette-cell__"]') as HTMLElement
+
+	// Drop over palette A's area — that is outside palette B's own root, so the swatch must be deleted.
+	await user.pointer({ keys: '[MouseLeft>]', target: cellB })
+	const drag = document.querySelector('#drag') as HTMLElement
+	drag.getBoundingClientRect = () => boundingRect(50, 50, 60, 60)
+	await user.pointer('[/MouseLeft]')
+
+	expect(cellB).not.toBeInTheDocument()
 })
 
 test('Displays transparent slot if showTransparentSlot is truthy', async () => {

--- a/src/lib/components/useDeletion.ts
+++ b/src/lib/components/useDeletion.ts
@@ -11,11 +11,6 @@ export interface UseDeletionOptions {
 	onDelete?: () => void
 	tooltipContentSelector?: string | null
 	tooltipClassName?: string | null
-	/**
-	 * Selector of the element treated as the "inside" area in `drop` mode. Resolved through a
-	 * document-wide `document.querySelector`, so callers rendering several palettes must pass a
-	 * selector unique to the owning instance. Defaults to `.palette` for direct action users.
-	 */
 	areaSelector?: string | null
 }
 
@@ -37,11 +32,6 @@ const createAction = (node: HTMLElement, deletionMode: DeletionMode | undefined,
 				},
 				containerClassName: options.tooltipClassName,
 				portal: false,
-				// Trigger the deletion tooltip on pointer hover only. The library also opens on
-				// `focusin` by default, which would pop the tooltip on every slot the grid's
-				// roving tabindex moves focus to during keyboard navigation. Keyboard users
-				// delete the focused slot with `Delete`/`Backspace` instead (handled by the
-				// listbox in `Palette.svelte`).
 				showOn: ['mouseenter'],
 				hideOn: ['mouseleave'],
 			})

--- a/src/lib/components/useDeletion.ts
+++ b/src/lib/components/useDeletion.ts
@@ -11,6 +11,12 @@ export interface UseDeletionOptions {
 	onDelete?: () => void
 	tooltipContentSelector?: string | null
 	tooltipClassName?: string | null
+	/**
+	 * Selector of the element treated as the "inside" area in `drop` mode. Resolved through a
+	 * document-wide `document.querySelector`, so callers rendering several palettes must pass a
+	 * selector unique to the owning instance. Defaults to `.palette` for direct action users.
+	 */
+	areaSelector?: string | null
 }
 
 export interface UseDeletionParameter extends UseDeletionOptions {
@@ -47,7 +53,7 @@ const createAction = (node: HTMLElement, deletionMode: DeletionMode | undefined,
 				dragImage.removeAttribute('data-testid')
 			}
 			return useDropOutside(node, {
-				areaSelector: '.palette',
+				areaSelector: options.areaSelector || '.palette',
 				animate: true,
 				dragImage,
 				dragHandleCentered: true,


### PR DESCRIPTION
## Summary
Each `<Palette>` now scopes the `deletionMode="drop"` "inside" area to its own root element instead of the document-global `.palette` selector. When several palettes were mounted on the same page, every instance resolved `.palette` to the first palette in the document via a single `document.querySelector`, so all but the first tested "inside vs. outside" against an unrelated element — deleting swatches dragged within their own palette (data loss) and silently ignoring drops over the first palette.

## Changes
- `useDeletion` accepts an optional `areaSelector` (default `.palette`, preserving behavior for direct action users) and forwards it to `useDropOutside`.
- `Palette` tags its root with a `data-palette-id` attribute whose value comes from Svelte's built-in `$props.id()`, and passes `[data-palette-id="<id>"]` as the drop area selector at both the flat-slot and grouped-slot `useDeletion` call sites, so each instance scopes deletion to its own root. `$props.id()` is SSR-safe (the client reuses the server-generated id through the hydration marker rather than recomputing it), and using a data attribute instead of `id` avoids clobbering any `id` the consumer sets on the palette root.
- Bumps the `svelte` peer dependency to `^5.20.0`, the first version to expose `$props.id()`.

## Test plan
- [ ] Two `deletionMode="drop"` palettes: a swatch dropped inside its own palette is a no-op.
- [ ] A swatch dropped outside its own palette is deleted, even when it lands over another palette.
- [ ] Existing single-palette drop / tooltip / keyboard deletion tests still pass.

Both new regression tests were verified to fail against the pre-fix behavior.

Closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)
