### PR TITLE
fix: Discard superseded async colors resolutions

### DIFF
--- a/src/lib/components/Palette.svelte
+++ b/src/lib/components/Palette.svelte
@@ -129,6 +129,7 @@
 	let _focusedIndex = $state<number | null>(null)
 	let _skipColorsSync = $state(false)
 	let _syncedViewParams: ReturnType<typeof _viewParams> | null = null
+	let _colorsGeneration = 0
 
 	const _viewParams = () => ({
 		isCompact: _isCompact,
@@ -164,6 +165,7 @@
 	$effect(() => {
 		const _source = colors
 		const _params = _viewParams()
+		const generation = ++_colorsGeneration
 		if (untrack(() => _skipColorsSync)) {
 			_skipColorsSync = false
 			if (_sameViewParams(_syncedViewParams, _params)) {
@@ -171,6 +173,9 @@
 			}
 		}
 		Promise.resolve(_source).then((results) => {
+			if (generation !== _colorsGeneration) {
+				return
+			}
 			if (!!results) {
 				_focusedIndex = null
 				if (isColorGroups(results)) {

--- a/src/lib/components/__tests__/Palette.test.ts
+++ b/src/lib/components/__tests__/Palette.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, expect, test, vi } from 'vitest'
 import { cleanup, render, screen, waitFor } from '@testing-library/svelte/svelte5'
 import userEvent from '@testing-library/user-event'
-import { createRawSnippet } from 'svelte'
+import { createRawSnippet, tick } from 'svelte'
 
 import Palette from '../Palette.svelte'
 import PaletteBind from './PaletteBind.test.svelte'
@@ -53,6 +53,39 @@ test('Displays as many color slots as set in async mode', async () => {
 
 	cells = await screen.findAllByTestId('__palette-cell__')
 	waitFor(() => expect(cells).toHaveLength(3))
+})
+
+test('Discards a stale async colors promise that settles after a newer one', async () => {
+	let resolveStale!: (value: string[]) => void
+	let resolveFresh!: (value: string[]) => void
+	const stalePromise = new Promise<string[]>((resolve) => (resolveStale = resolve))
+	const freshPromise = new Promise<string[]>((resolve) => (resolveFresh = resolve))
+
+	const { component } = setup(PaletteReactive, {
+		props: { initialColors: stalePromise },
+	})
+
+	// The first (slow) request is in flight; nothing is painted yet.
+	await tick()
+	expect(screen.queryAllByTestId('__palette-slot__')).toHaveLength(0)
+
+	// A newer request supersedes it before either settles.
+	component.setColors(freshPromise)
+	await tick()
+
+	// The newer request wins the race and paints its colors.
+	resolveFresh(['#111', '#222'])
+	await waitFor(() => expect(screen.getAllByTestId('__palette-slot__')).toHaveLength(2))
+
+	// The stale request settles last; it must not clobber the newer result.
+	resolveStale(['#aaa', '#bbb', '#ccc'])
+	await stalePromise
+	await tick()
+	await tick()
+
+	const slots = screen.getAllByTestId('__palette-slot__')
+	expect(slots).toHaveLength(2)
+	expect(slots.map((slot) => slot.getAttribute('aria-label'))).toEqual(['#111', '#222'])
 })
 
 test('Triggers select with color', async () => {


### PR DESCRIPTION
## Summary

The `$effect` that resolves the `colors` prop attached a `Promise.resolve(colors).then(...)` callback on every run without invalidating earlier ones. When `colors` was reassigned to a new promise before the previous one settled, whichever promise resolved **last** won — so a slow, stale request could permanently clobber a newer, faster one. The failure was silent and self-perpetuating: the effect only re-runs on a prop change, so the palette kept rendering the discarded request's colors.

This affects any consumer using the documented async form of `colors` (a palette keyed to a selected theme/project/tenant, a search/filter, a retry) whenever concurrent responses come back out of order.

## Changes

- **`Palette.svelte`** — capture a per-run generation token (`_colorsGeneration`) at the top of the colors-resolving effect, and discard any resolution whose generation is no longer current. The last **requested** value now wins rather than the last **settled** one. Bumping the token on every run also protects the synchronous write-back path (`_skipColorsSync`), so an in-flight promise can no longer overwrite a color added/removed after it.
- **`Palette.test.ts`** — regression test that renders with a slow in-flight promise, swaps in a faster one, resolves the fast one first and the stale one last, and asserts the fast promise's colors remain rendered. The test fails (renders the stale 3 colors) when the guard is removed and passes with it.

## Test plan

- [x] `yarn test:ci` — 776 tests pass (new regression test included)
- [x] New test verified load-bearing: fails with the guard neutered, passes with it
- [x] `yarn run check` — svelte-check, 0 errors / 0 warnings
- [x] `yarn lint` — prettier clean
- [x] `yarn build` — build + `svelte-package` + publint OK

## Breaking changes

None. Behavior-only correction; the public API is unchanged.

Closes #170