### PR TITLE
docs: fix eyedropper export name

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,11 @@ If the API is not available, nothing will be rendered.
 
 > **Browser compatibility note:** The EyeDropper API specification defines `sRGBHex` as returning a hexadecimal color string (e.g. `#rrggbb`). However, some browsers return an `rgb()` or `rgba()` string instead. The component normalizes the value to hex format automatically.
 
-> The PaletteEyeDropper component can be used on its own anywhere within a snippet or in an external component as it is exported from this lib.
+> The `PaletteEyeDropperButton` component can be used on its own anywhere within a snippet or in an external component as it is exported from this lib:
+>
+> ```js
+> import { PaletteEyeDropperButton } from '@untemps/svelte-palette'
+> ```
 
 ## Transition
 


### PR DESCRIPTION
## Summary

- Fix the standalone EyeDropper component name in the README
- Add a copyable import example for `PaletteEyeDropperButton`

Fixes #199.

## Verification

- `rg -n "PaletteEyeDropper component" README.md` returns no matches
- `rg -n "import \{ PaletteEyeDropperButton \} from '@untemps/svelte-palette'" README.md`
- `rg -n "export \{ default as PaletteEyeDropperButton \}" src/lib/index.ts`
- `git diff --check HEAD^ HEAD`

No build was run because this is a README-only documentation update.