### PR TITLE
fix: PaletteTrashButton isActive has no effect

### DIFF
--- a/src/lib/components/PaletteTrashButton.svelte
+++ b/src/lib/components/PaletteTrashButton.svelte
@@ -25,7 +25,7 @@
 	type="button"
 	{...restProps}
 	class="trash_button__button {className}"
-	class:icon_button__button--active={isActive}
+	class:trash_button__button--active={isActive}
 	{onclick}
 >
 	<TrashIcon />

--- a/src/lib/components/__tests__/PaletteTrashButton.test.ts
+++ b/src/lib/components/__tests__/PaletteTrashButton.test.ts
@@ -30,5 +30,13 @@ test('Triggers click event', async () => {
 test('Attaches active class when isActive is true', () => {
 	setup(PaletteTrashButton, { props: { isActive: true } })
 	const button = screen.getByTestId('__palette-trash-button__')
-	expect(button).toHaveClass('icon_button__button--active')
+	// The class must match the component's own scoped rule, not PaletteIconButton's namespace (#175).
+	expect(button).toHaveClass('trash_button__button--active')
+	expect(button).not.toHaveClass('icon_button__button--active')
+})
+
+test('Does not attach active class when isActive is false', () => {
+	setup(PaletteTrashButton, { props: { isActive: false } })
+	const button = screen.getByTestId('__palette-trash-button__')
+	expect(button).not.toHaveClass('trash_button__button--active')
 })


### PR DESCRIPTION
## Summary
`PaletteTrashButton` toggled `icon_button__button--active` — a class that only exists in `PaletteIconButton`'s scoped stylesheet. Because Svelte scopes each component's CSS to a distinct hash, that class could never match the `.trash_button__button--active` rule the trash button actually ships, so the `isActive` prop had no visual effect at all. This binds the component's own class instead.

## Changes
- `PaletteTrashButton.svelte` — bind `class:trash_button__button--active={isActive}` instead of the foreign `icon_button__button--active`, so `isActive` toggles the component's own active background.
- `PaletteTrashButton.test.ts` — fix the assertion to the correct class name, and additionally assert the foreign `icon_button__button--active` is **not** present, so the exact regression is caught. (jsdom's `getComputedStyle` does not resolve Svelte's scoped compound selectors, so a computed-style assertion is not viable in this environment — verified empirically.)

## Test plan
- [ ] `yarn test:ci` — full suite green (786 tests)
- [ ] `yarn build` — vite build + svelte-package + publint all pass
- [ ] `yarn run check` — svelte-check 0 errors / 0 warnings
- [ ] `yarn lint` — prettier clean
- [ ] Manual: a consumer setting `isActive` on `PaletteTrashButton` now sees the active background (`#e5e5e5`)

## Follow-up (out of scope)
`PaletteTrashButton` and `PaletteIconButton` duplicate near-identical button/active/focus styling under two BEM namespaces, which is what made this mix-up possible. Delegating the trash button to `PaletteIconButton` with `icon={TRASH}` would remove the duplication at its root, but it would also change the rendered appearance (size, border, icon dimensions, focus color), so it belongs in a separate change.

Closes #175