### PR TITLE
test(eyedropper): Cover and consolidate the default accessible name

### DIFF
--- a/src/lib/components/PaletteInput.svelte
+++ b/src/lib/components/PaletteInput.svelte
@@ -106,7 +106,7 @@
 			/>
 		</span>
 		{#if _isEyeDropperAvailable && inputType !== 'color'}
-			<PaletteEyeDropperButton aria-label="Pick a color from the screen" onadd={_onEyeDropperAdd} />
+			<PaletteEyeDropperButton onadd={_onEyeDropperAdd} />
 		{/if}
 	</form>
 </section>

--- a/src/lib/components/__tests__/PaletteEyeDropperButton.test.ts
+++ b/src/lib/components/__tests__/PaletteEyeDropperButton.test.ts
@@ -42,6 +42,15 @@ test('Renders eye dropper button', async () => {
 	expect(button).toBeInTheDocument()
 })
 
+// The icon-only button has no text content, so its aria-label is the sole source of
+// its accessible name. Assert the default (no props) so a regression to a mislabeled
+// value — e.g. the old "Submit the hex color value" — is caught rather than passing CI.
+test('Sets a default aria-label describing the pick action', () => {
+	setup(PaletteEyeDropperButton)
+	const button = screen.getByRole('button', { name: 'Pick a color from the screen' })
+	expect(button).toBeInTheDocument()
+})
+
 test('Sets eye dropper button aria-label', () => {
 	const ariaLabel = 'Foo'
 	setup(PaletteEyeDropperButton, { ['aria-label']: ariaLabel })

--- a/src/lib/components/__tests__/PaletteEyeDropperButton.test.ts
+++ b/src/lib/components/__tests__/PaletteEyeDropperButton.test.ts
@@ -42,9 +42,6 @@ test('Renders eye dropper button', async () => {
 	expect(button).toBeInTheDocument()
 })
 
-// The icon-only button has no text content, so its aria-label is the sole source of
-// its accessible name. Assert the default (no props) so a regression to a mislabeled
-// value — e.g. the old "Submit the hex color value" — is caught rather than passing CI.
 test('Sets a default aria-label describing the pick action', () => {
 	setup(PaletteEyeDropperButton)
 	const button = screen.getByRole('button', { name: 'Pick a color from the screen' })

--- a/src/lib/components/__tests__/PaletteInput.test.ts
+++ b/src/lib/components/__tests__/PaletteInput.test.ts
@@ -33,10 +33,6 @@ test('Enables submit button when input color is valid', async () => {
 	expect(button).toBeDisabled()
 	await user.type(input, 'ff')
 	expect(button).toBeDisabled()
-	// _onInputChange reformats to "#$1" on each keystroke, so the typed digits land as
-	// "#ffff00" — a valid 6-digit hex. Typing "ff0" here would stop at "#ffff0" (5 digits,
-	// invalid), leaving the button disabled. The waitFor must be awaited so the assertion
-	// actually runs instead of floating as an unhandled rejection.
 	await user.type(input, 'ff00')
 	await waitFor(() => expect(button).toBeEnabled())
 })
@@ -72,9 +68,6 @@ test('Does not render the eyedropper as a submit button', async () => {
 	expect(button).toHaveAttribute('type', 'button')
 })
 
-// The bundled path no longer passes an aria-label; it inherits the component
-// default. Assert the inherited accessible name so dropping the override cannot
-// silently regress the label a screen reader announces.
 test('Inherits the default eyedropper accessible name', async () => {
 	stubEyeDropper('#ff0')
 	setup(PaletteInput)

--- a/src/lib/components/__tests__/PaletteInput.test.ts
+++ b/src/lib/components/__tests__/PaletteInput.test.ts
@@ -68,6 +68,16 @@ test('Does not render the eyedropper as a submit button', async () => {
 	expect(button).toHaveAttribute('type', 'button')
 })
 
+// The bundled path no longer passes an aria-label; it inherits the component
+// default. Assert the inherited accessible name so dropping the override cannot
+// silently regress the label a screen reader announces.
+test('Inherits the default eyedropper accessible name', async () => {
+	stubEyeDropper('#ff0')
+	setup(PaletteInput)
+	const button = await screen.findByRole('button', { name: 'Pick a color from the screen' })
+	expect(button).toBeInTheDocument()
+})
+
 test('Does not render the add button as a submit button', async () => {
 	setup(PaletteInput)
 	const button = screen.getByTestId('__palette-input-submit__')

--- a/src/lib/components/__tests__/PaletteInput.test.ts
+++ b/src/lib/components/__tests__/PaletteInput.test.ts
@@ -33,8 +33,12 @@ test('Enables submit button when input color is valid', async () => {
 	expect(button).toBeDisabled()
 	await user.type(input, 'ff')
 	expect(button).toBeDisabled()
-	await user.type(input, 'ff0')
-	waitFor(() => expect(button).toBeEnabled())
+	// _onInputChange reformats to "#$1" on each keystroke, so the typed digits land as
+	// "#ffff00" — a valid 6-digit hex. Typing "ff0" here would stop at "#ffff0" (5 digits,
+	// invalid), leaving the button disabled. The waitFor must be awaited so the assertion
+	// actually runs instead of floating as an unhandled rejection.
+	await user.type(input, 'ff00')
+	await waitFor(() => expect(button).toBeEnabled())
 })
 
 test('Enables submit button when set color is valid', async () => {


### PR DESCRIPTION
## Summary

Completes the remaining cleanup from #181 and locks in the eyedropper button's accessible name with tests. The core WCAG 4.1.2 fix (default `aria-label` → `"Pick a color from the screen"` and dropping `type="submit"`) already landed in #216, so this PR is test coverage + a small consolidation, with no runtime behaviour change and no release impact.

## Context

#181 flagged that `PaletteEyeDropperButton` shipped a copy-pasted `aria-label="Submit the hex color value"`, misdescribing an icon-only control that actually opens the browser EyeDropper. That default label (and the `type="submit"`) was already corrected in #216. What remained from the issue was the two follow-ups it proposed — plus a false-positive test that surfaced while verifying this change.

## Changes

- **`test(eyedropper)`** — Assert the **default** accessible name (`getByRole('button', { name: 'Pick a color from the screen' })` with no props). Previously only the caller-supplied override path (`'Foo'`) was covered, so a regression of the default would have passed CI unnoticed — exactly what let the original bug hide.
- **`chore(input)`** — Drop the now-redundant `aria-label` override on `<PaletteEyeDropperButton>` inside `PaletteInput`; it now inherits the component default (single source of truth). The rendered DOM is byte-identical. A guard test asserts the bundled button still exposes the inherited name.
- **`test(input)`** — Fix a pre-existing false-positive test discovered during review. `"enables submit when valid"` typed `"ff0"`, which `_onInputChange` reformats to `"#ffff0"` (5 hex digits → invalid), so the button never enabled; the `waitFor` was also un-awaited, so the failing assertion floated as an unhandled rejection instead of failing the test. Now types `"ff00"` (→ `"#ffff00"`, valid) and awaits the assertion.

## Test plan

- [x] `yarn test:ci` — 804 passing (added the default-name test and the inherited-name guard; hardened the enable test)
- [x] `yarn run check` — svelte-check 0 errors / 0 warnings
- [x] `yarn lint` — prettier clean
- [x] `yarn build` — package + publint clean
- [x] Mutation-verified the fixed enable test: reverting to `"ff0"` makes it fail on `toBeEnabled()`, confirming it no longer false-passes.

## Notes

- No public API change and no `feat`/`fix` commit, so no version bump.
- Targets `beta` (active 6.0 line). GitHub won't auto-close #181 from a non-default base — please close it manually on merge.

Closes #181
