### PR TITLE
fix(loader): Announce loading state and honor reduced motion

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,6 +435,8 @@ In case you want to call an API to fetch the palette colors, you may pass a prom
 
 The component displays a customizable loader waiting to the promise to be resolved. Be aware that the result of the promise must be an array of color strings as well. The color input and the compact toggle only appear once the promise has resolved.
 
+The default loader (`PaletteLoader`) is an accessible live region: it exposes a `role="status"` so screen readers announce the loading state, and its spinner is driven by a CSS animation that is disabled under `prefers-reduced-motion: reduce`. When you render `PaletteLoader` directly, its announced text comes from a `label` prop (defaults to `Loading colors`). Through `<Palette>` the default loader announces that English default, so to localize the loading announcement — or to replace the loader entirely — supply your own `loader` snippet.
+
 #### Example
 
 ```svelte

--- a/src/lib/components/PaletteLoader.svelte
+++ b/src/lib/components/PaletteLoader.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	interface Props {
-		/** Accessible name announced while the palette colors are loading. */
+		/** Text announced by assistive tech while the palette colors are loading. */
 		label?: string
 	}
 

--- a/src/lib/components/PaletteLoader.svelte
+++ b/src/lib/components/PaletteLoader.svelte
@@ -1,15 +1,52 @@
-<script lang="ts"></script>
+<script lang="ts">
+	interface Props {
+		/** Accessible name announced while the palette colors are loading. */
+		label?: string
+	}
 
-<svg width="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-	<path d="M12,2.5 A9.5,9.5 0 0,1 21.5,12" stroke-width="2" stroke="#ccc" fill="none">
-		<animateTransform
-			attributeName="transform"
-			type="rotate"
-			from="0 12 12"
-			to="360 12 12"
-			dur="1s"
-			repeatCount="indefinite"
-			calcMode="linear"
-		/>
-	</path>
-</svg>
+	let { label = 'Loading colors' }: Props = $props()
+</script>
+
+<div class="palette__loader" role="status">
+	<svg
+		class="palette__loader__spinner"
+		width="24"
+		viewBox="0 0 24 24"
+		aria-hidden="true"
+		xmlns="http://www.w3.org/2000/svg"
+	>
+		<path d="M12,2.5 A9.5,9.5 0 0,1 21.5,12" stroke-width="2" stroke="#ccc" fill="none" />
+	</svg>
+	<span class="palette__loader__label">{label}</span>
+</div>
+
+<style>
+	.palette__loader__spinner {
+		transform-origin: 50% 50%;
+		animation: palette-spin 1s linear infinite;
+	}
+
+	.palette__loader__label {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		padding: 0;
+		margin: -1px;
+		overflow: hidden;
+		clip: rect(0, 0, 0, 0);
+		white-space: nowrap;
+		border: 0;
+	}
+
+	@keyframes palette-spin {
+		to {
+			transform: rotate(360deg);
+		}
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.palette__loader__spinner {
+			animation: none;
+		}
+	}
+</style>

--- a/src/lib/components/__tests__/PaletteLoader.test.ts
+++ b/src/lib/components/__tests__/PaletteLoader.test.ts
@@ -9,8 +9,6 @@ test('Exposes a live status region', () => {
 
 test('Announces the default loading label', () => {
 	render(PaletteLoader)
-	// role="status" is a polite live region: screen readers announce its text
-	// content, so the label must be exposed as real text (not just an aria name).
 	expect(screen.getByRole('status')).toHaveTextContent('Loading colors')
 })
 

--- a/src/lib/components/__tests__/PaletteLoader.test.ts
+++ b/src/lib/components/__tests__/PaletteLoader.test.ts
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/svelte/svelte5'
+
+import PaletteLoader from '../PaletteLoader.svelte'
+
+test('Exposes a live status region', () => {
+	render(PaletteLoader)
+	expect(screen.getByRole('status')).toBeInTheDocument()
+})
+
+test('Announces the default loading label', () => {
+	render(PaletteLoader)
+	// role="status" is a polite live region: screen readers announce its text
+	// content, so the label must be exposed as real text (not just an aria name).
+	expect(screen.getByRole('status')).toHaveTextContent('Loading colors')
+})
+
+test('Announces a custom loading label', () => {
+	render(PaletteLoader, { props: { label: 'Chargement des couleurs' } })
+	expect(screen.getByRole('status')).toHaveTextContent('Chargement des couleurs')
+})
+
+test('Hides the spinner graphic from assistive tech', () => {
+	const { container } = render(PaletteLoader)
+	const spinner = container.querySelector('.palette__loader__spinner')
+	expect(spinner).toHaveAttribute('aria-hidden', 'true')
+})


### PR DESCRIPTION
## Summary

The async loading spinner (`PaletteLoader`) was invisible to assistive tech and could not be stopped under reduced-motion preferences. While a `colors` promise is pending, the loader is the *entire* rendered content of the palette, so a screen-reader user got total silence, and the SMIL-driven spin ran regardless of `prefers-reduced-motion`.

This fixes both accessibility defects called out in #192:

- **WCAG 4.1.3 (Status Messages):** the loader had no `role="status"`, no live region, and no accessible name — the pending state was announced as nothing.
- **WCAG 2.2.2 (Pause, Stop, Hide):** the rotation was a SMIL `<animateTransform>`, which is not CSS and cannot be disabled by `prefers-reduced-motion`.

## Changes

- **`PaletteLoader.svelte`** — wrap the spinner in a `role="status"` live region (implies `aria-live="polite"` + `aria-atomic="true"`) whose announced text is carried by real, visually-hidden text. The decorative `<svg>` is now `aria-hidden="true"`. The rotation moves from SMIL to a CSS `@keyframes` animation with a `@media (prefers-reduced-motion: reduce) { animation: none }` block. A localizable `label` prop (default `Loading colors`) sets the announced text for consumers rendering `PaletteLoader` directly.
- **`PaletteLoader.test.ts`** (new) — the component had no test file. Covers the status role, the default and custom announced labels, and the `aria-hidden` spinner.
- **`README.md`** — document the loader's accessibility behavior in the async-loading recipe.

## Implementation notes

- The CSS animation targets the **root** `<svg>` element rather than the `<path>`, which sidesteps the SVG `transform-box` gotcha: on the root svg (a replaced CSS box) `transform-origin: 50% 50%` resolves to the true center in Chrome/Firefox/Safari with no `transform-box` needed, so the arc spins about its center identically to the old SMIL behavior.
- `role="status"` does not derive an accessible name from its content per the accname spec, so the tests assert the announced live-region **text content** (what a screen reader reads) rather than an ARIA accessible name.
- No visual or API breaking change: the spinner keeps its 24px size, and the `label` prop is optional with a default.

## Test plan

- [x] `yarn test:ci` — 816 tests pass (4 new), `PaletteLoader` fully covered
- [x] `yarn build` — `vite build` + `svelte-package` + `publint` ("All good!")
- [x] `yarn lint` — `prettier --check` clean
- [x] `yarn run check` — `svelte-check` 0 errors
- [ ] Manual: with a screen reader, a pending `colors` promise announces "Loading colors"; with `prefers-reduced-motion: reduce`, the spinner does not animate

Closes #192

> Targets `beta` (the active 6.0 line). Because this PR does not target the default branch, GitHub will not auto-close #192 on merge — it will be closed manually at release.