### PR TITLE
fix: correct 'global' to 'globals' typo in vitest config

### DIFF
--- a/vitest.config.js
+++ b/vitest.config.js
@@ -3,7 +3,7 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
 	test: {
-		global: true,
+		globals: true,
 		environment: 'jsdom',
 		coverage: {
 			reporter: ['text', 'lcov'],


### PR DESCRIPTION
## Summary
Vitest does not recognize `global` as a valid `test` option — the correct key is `globals: true`. Without this fix, test globals are silently not injected.

## Fix
`vitest.config.js:6`: `global: true` → `globals: true`

## Testing
After this fix, `vi.fn()`, `describe`, `it`, etc. should be available as globals in test files.

---
*Found via typo search. Happy to address any feedback.*