### PR TITLE
chore(husky): Quote the commit-msg hook argument

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,1 @@
-npx --no -- commitlint --edit $1
+npx --no -- commitlint --edit "$1"


### PR DESCRIPTION
## Summary

Resolves #193 by aligning with the `untemps/react-vocal` convention rather than adding a CI lint gate. react-vocal enforces formatting/quality **locally through husky hooks**, not through CI: its `publish.yml` runs only `install → test:ci → build → release`, and formatting is handled by the pre-commit `yarn prettier` hook plus commitlint on the message — it never runs its `lint` script in CI.

This repo already mirrors that model (and additionally runs `yarn run check` in both CI and the pre-commit hook). So #193 is resolved by keeping enforcement local and aligning the hooks with the template, instead of introducing a `pull_request` workflow or a `yarn lint` step that would diverge from react-vocal.

The only husky divergence from the react-vocal template was the `commit-msg` hook not quoting its argument — fixed here.

## Changes

- `.husky/commit-msg`: `commitlint --edit $1` → `commitlint --edit "$1"` (quote the argument — robustness against paths with spaces, and parity with the react-vocal template).

## Notes

- No CI change: consistent with react-vocal, formatting/quality stays enforced by the husky hooks (`pre-commit`: svelte-check + tests + prettier write; `commit-msg`: commitlint). The `lint` script and `pre-commit` are intentionally left untouched.
- `chore(husky)` does not trigger a release (this repo only bumps on `scope: force`).

## Test plan

- [ ] `commit-msg` hook runs commitlint against the message and rejects a non-conventional subject (exercised by this branch's own commit).
- [ ] `pre-commit` hook stays green (`yarn run check && yarn test:ci && yarn prettier`).

Closes #193