### PR TITLE
fix: Hide the input preview slot from assistive tech

### DIFF
--- a/src/lib/components/PaletteInput.svelte
+++ b/src/lib/components/PaletteInput.svelte
@@ -78,7 +78,7 @@
 		{#if inputType !== 'color'}<PaletteSlot
 				data-testid="__palette-input-slot__"
 				{color}
-				role="presentation"
+				aria-hidden="true"
 				tabindex={-1}
 				disabled
 			/>{/if}

--- a/src/lib/components/__tests__/PaletteInput.test.ts
+++ b/src/lib/components/__tests__/PaletteInput.test.ts
@@ -123,6 +123,21 @@ test('Does not display slot if inputType is "color"', async () => {
 	expect(button).not.toBeInTheDocument()
 })
 
+test('Hides the decorative preview swatch from the accessibility tree', async () => {
+	// The swatch is purely decorative; `role="presentation"` would be ignored because
+	// PaletteSlot always carries a global `aria-label`, so it must use `aria-hidden` to
+	// actually leave the accessibility tree. This attribute is the load-bearing assertion:
+	// it is absent on the old `role="presentation"` markup, so this test fails against it.
+	setup(PaletteInput, { color: '#ff0' })
+	const slot = screen.getByTestId('__palette-input-slot__')
+	expect(slot).toHaveAttribute('aria-hidden', 'true')
+	// Sanity check that the preview is not exposed as a second button beside the submit
+	// control. jsdom already excluded the old presentation-role swatch here (it does not
+	// model the browser-only presentational-conflict rule), so this guards the new
+	// behaviour rather than reproducing the original leak.
+	expect(screen.queryAllByRole('button')).toEqual([screen.getByTestId('__palette-input-submit__')])
+})
+
 test('Does not display EyeDropper button if API is not available', async () => {
 	vi.stubGlobal('EyeDropper', undefined)
 	setup(PaletteInput, {


### PR DESCRIPTION
## Summary

`PaletteInput` renders its decorative color-preview slot through `PaletteSlot` with `role="presentation"` to keep it out of the accessibility tree. But `PaletteSlot` unconditionally emits a global `aria-label={color}` on its `<button>`. Per the ARIA [presentational-roles conflict resolution](https://www.w3.org/TR/wai-aria-1.2/#conflict_resolution_presentation_none) rule, an element carrying a global ARIA attribute has `role="presentation"` **ignored** and is exposed with its implicit role — here, `button`. So the preview leaked into the a11y tree as a redundant, disabled button named after the current color, duplicating the value already announced by the adjacent text input.

This replaces `role="presentation"` with `aria-hidden="true"`, which prunes the element and its `aria-label` from the accessibility tree unconditionally — the actual intent. It is safe because the slot stays non-focusable (`disabled` + `tabindex={-1}`) and conveys nothing the input does not already expose.

`PaletteSlot` itself is untouched: consumers that override `aria-label` (e.g. the transparent slot in `Palette.svelte`) keep working exactly as before.

## Changes

- `src/lib/components/PaletteInput.svelte` — swap `role="presentation"` → `aria-hidden="true"` on the preview slot (keeping `disabled` and `tabindex={-1}`).
- `src/lib/components/__tests__/PaletteInput.test.ts` — add a test asserting the slot carries `aria-hidden="true"` (the red-green anchor: absent on the old markup) and is not exposed as a second button beside the submit control.

## Test plan

- [x] `yarn test:ci` — 817 tests pass
- [x] `yarn build` — library builds and `publint` passes
- [x] `yarn lint` — prettier clean
- [x] `yarn run check` — svelte-check: 0 errors / 0 warnings (no a11y warning for `aria-hidden` on the disabled button)
- [ ] Screen-reader spot check: the preview slot no longer appears as a control when browsing `PaletteInput` by element.

## Breaking changes

None. Purely an accessibility-tree change — no visual, keyboard, or public-API change.

Closes #194
