### PR TITLE
docs: Correct the slot snippet name in the Groups section

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Snippets replace the Svelte 4 named slots API. Pass them as children of `<Palett
 | ----------------- | ----------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
 | `header`          | Allow to add a header to the palette. By default, it is empty.                      | `selectedColor`                                                                                                                    |
 | `footer`          | Allow to add a footer to the palette. By default, it is empty.                      | `selectedColor`                                                                                                                    |
-| `slot`            | Allow to replace the default color slots.                                           | `index`, `color`, `colorName`, `groupName`, `selectedColor`, `selected`, `transition`, `isCompact`, `tabindex`, `ariaKeyShortcuts` |
+| `slot`            | Allow to replace the default color slots. `groupName` is only set in grouped mode.  | `index`, `color`, `colorName`, `groupName`, `selectedColor`, `selected`, `transition`, `isCompact`, `tabindex`, `ariaKeyShortcuts` |
 | `transparentSlot` | Allow to replace the default transparent slot.                                      | `tabindex`, `selected`                                                                                                             |
 | `beforeSlot`      | Allow to add an element before the color slots.                                     | `selectedColor`, `transition`, `isCompact`                                                                                         |
 | `afterSlot`       | Allow to add an element after the color slots.                                      | `selectedColor`, `transition`, `isCompact`                                                                                         |
@@ -201,7 +201,7 @@ Each group has:
 - `name` (optional) — displayed as a label above the group
 - `colors` — array of color strings or color objects
 
-When groups are used, compact mode and the color input are not available. The `colorSlot` snippet receives an additional `groupName` parameter.
+When groups are used, compact mode and the color input are not available. The `slot` snippet receives an additional `groupName` parameter.
 
 ## Promise
 


### PR DESCRIPTION
## Summary

The "Array of Color Groups" section of the README referred to the color slot snippet as `colorSlot`, but the public snippet prop is named `slot`. `colorSlot` is only the internal local alias (`Palette.svelte` destructures `slot: colorSlot`), invisible to consumers. A reader following the Groups section verbatim would write `{#snippet colorSlot(...)}`, which is silently ignored — the snippet never renders and the palette falls back to the default slot, with no error.

The README already documented the real name everywhere else (snippet table, Example), so the docs contradicted themselves.

## Changes

- Rename `colorSlot` → `slot` in the Groups section sentence.
- Note in the `slot` snippet table row that `groupName` is only set in grouped mode, so the table and the Groups section state the same contract. (`groupName` is passed only in the group-mode render and omitted in flat mode.)

## Test plan

- [ ] Snippet table `slot` row, Example, and Groups section all use the name `slot`.
- [ ] `yarn lint` (prettier) passes — README stays formatted.
- [ ] No public API or behavior change; docs only.

Closes #200