### PR TITLE
docs: Add missing closing style tag in Basic Usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,15 +32,9 @@ yarn add @untemps/svelte-palette
 
 ```svelte
 <script>
-    import { Palette } from '@untemps/svelte-palette'
+	import { Palette } from '@untemps/svelte-palette'
 
-    const colors = [
-		'#865C54',
-		'#8F5447',
-		'#A65846',
-		'#A9715E',
-		'#AD8C72',
-    ]
+	const colors = ['#865C54', '#8F5447', '#A65846', '#A9715E', '#AD8C72']
 
 	let bgColor = colors[0]
 </script>
@@ -57,6 +51,7 @@ yarn add @untemps/svelte-palette
 		height: 100%;
 		background-color: var(--bgColor);
 	}
+</style>
 ```
 
 ## API


### PR DESCRIPTION
## Summary

The `Basic Usage` snippet in `README.md` opened a `<style>` element that was never closed — the fenced `svelte` block terminated right after the closing brace of the `main` CSS rule, so the very first example a reader encounters did not compile if copy-pasted. This adds the missing `</style>` tag.

Making the block valid means Prettier can now parse and format the embedded Svelte code, so `prettier --check .` also normalizes two pre-existing quirks in the snippet (4-space import indent → tab, multi-line `colors` array → single line). These are required to keep `yarn lint` green.

## Changes

- `README.md` — add the missing `</style>` closing tag to the Basic Usage example so it compiles as written; Prettier normalization of the now-valid block (tab indent, single-line `colors` array).

## Test plan

- [x] `yarn lint` (`prettier --check .`) passes — README was clean before, and the raw `</style>` addition alone would fail it without the accompanying formatting.
- [x] Pre-commit hook (`yarn check` + `yarn test:ci` + `yarn prettier`) runs green.
- [x] The snippet, as printed, is now a valid, compilable Svelte component.

Closes #201