### PR TITLE
fix: Strip phantom disclosure ARIA from deletion tooltip cells

### DIFF
--- a/src/lib/components/__tests__/Palette.test.ts
+++ b/src/lib/components/__tests__/Palette.test.ts
@@ -947,6 +947,70 @@ test('Keeps deletion cells out of the tab order', async () => {
 	})
 })
 
+test('Keeps disclosure ARIA off the presentational deletion cells', async () => {
+	const colors = ['#ff0', '#0ff', '#f0f']
+	const { user } = setup(Palette, { props: { colors, deletionMode: TOOLTIP } })
+
+	const cells = await screen.findAllByTestId('__palette-cell__')
+	expect(cells.length).toBeGreaterThan(0)
+
+	// The tooltip library treats the pointer-only deletion tooltip as an interactive disclosure
+	// and would stamp aria-haspopup/aria-expanded on the role="presentation" cells. Assert the
+	// attributes directly: role queries read `role` literally and ignore the presentational
+	// conflict these attributes trigger.
+	cells.forEach((cell) => {
+		expect(cell).not.toHaveAttribute('aria-haspopup')
+		expect(cell).not.toHaveAttribute('aria-expanded')
+	})
+
+	// The library re-applies aria-expanded every time the tooltip opens; opening it on hover
+	// must not leave disclosure semantics behind on the presentational cell.
+	const cell = cells[0]
+	await user.hover(cell)
+	await screen.findByTestId('__trash-icon__')
+	// role="dialog" + aria-modal="true" are set only when the library treats the tooltip as an
+	// interactive disclosure — the precondition that stamps aria-expanded on open. Asserting it
+	// keeps the strip check below from passing vacuously if the content ever stops being focusable.
+	expect(await screen.findByRole('dialog')).toHaveAttribute('aria-modal', 'true')
+	await waitFor(() => {
+		expect(cell).not.toHaveAttribute('aria-haspopup')
+		expect(cell).not.toHaveAttribute('aria-expanded')
+	})
+
+	await user.unhover(cell)
+	await waitFor(() => {
+		expect(cell).not.toHaveAttribute('aria-haspopup')
+		expect(cell).not.toHaveAttribute('aria-expanded')
+	})
+})
+
+test('Strips aria-describedby stamped by a non-interactive custom deletion tooltip', async () => {
+	// A custom tooltip whose content has no focusable element makes the library treat the tooltip
+	// as non-interactive; on open it then sets aria-describedby on the presentational cell instead
+	// of the interactive disclosure attributes. That is the same presentational-conflict leak.
+	const template = document.createElement('template')
+	template.id = 'custom-deletion-tooltip'
+	template.innerHTML = '<span>Remove</span>'
+	document.body.appendChild(template)
+
+	try {
+		const colors = ['#ff0', '#0ff', '#f0f']
+		const { user } = setup(Palette, {
+			props: { colors, deletionMode: TOOLTIP, tooltipContentSelector: '#custom-deletion-tooltip' },
+		})
+
+		const cells = await screen.findAllByTestId('__palette-cell__')
+		const cell = cells[0]
+		await user.hover(cell)
+		await screen.findByText('Remove') // the custom tooltip opened
+		await waitFor(() => {
+			expect(cell).not.toHaveAttribute('aria-describedby')
+		})
+	} finally {
+		template.remove()
+	}
+})
+
 test('Keeps exactly one tabbable slot after the colors change', async () => {
 	const colors = ['#100', '#200', '#300', '#400', '#500', '#600']
 	const { rerender } = setup(Palette, { props: { colors, numColumns: 3 } })

--- a/src/lib/components/useDeletion.ts
+++ b/src/lib/components/useDeletion.ts
@@ -18,10 +18,31 @@ export interface UseDeletionParameter extends UseDeletionOptions {
 	deletionMode?: DeletionMode
 }
 
+const LEAKED_ARIA_ATTRIBUTES = ['aria-haspopup', 'aria-expanded', 'aria-describedby'] as const
+
+/**
+ * The tooltip library stamps disclosure semantics onto the presentational cell wrapper the
+ * deletion tooltip is bound to. When its content is interactive (the default template holds a
+ * focusable trash button) it sets `aria-haspopup="dialog"` and toggles `aria-expanded`; when it
+ * is non-interactive (a custom `tooltipContentSelector` whose content has no focusable element)
+ * it sets `aria-describedby` on open. The tooltip is pointer-only (`showOn: ['mouseenter']`), so
+ * on a `role="presentation"` cell these all announce an interaction that keyboard and
+ * assistive-technology users can never perform there — the keyboard path is the listbox-level
+ * Delete/Backspace shortcut instead. Strip them, and keep stripping: the library re-applies them
+ * on every open. Returns a disposer that stops the observer.
+ */
+const suppressAriaLeaks = (node: HTMLElement): (() => void) => {
+	const strip = () => LEAKED_ARIA_ATTRIBUTES.forEach((attribute) => node.removeAttribute(attribute))
+	strip()
+	const observer = new MutationObserver(strip)
+	observer.observe(node, { attributes: true, attributeFilter: [...LEAKED_ARIA_ATTRIBUTES] })
+	return () => observer.disconnect()
+}
+
 const createAction = (node: HTMLElement, deletionMode: DeletionMode | undefined, options: UseDeletionOptions) => {
 	switch (deletionMode) {
 		case TOOLTIP: {
-			return useTooltip(node, {
+			const action = useTooltip(node, {
 				contentSelector: options.tooltipContentSelector || '#tooltip-template',
 				contentActions: {
 					'*': {
@@ -35,6 +56,13 @@ const createAction = (node: HTMLElement, deletionMode: DeletionMode | undefined,
 				showOn: ['mouseenter'],
 				hideOn: ['mouseleave'],
 			})
+			const disposeAriaSuppression = suppressAriaLeaks(node)
+			return {
+				destroy: () => {
+					disposeAriaSuppression()
+					action?.destroy?.()
+				},
+			}
 		}
 		case DROP: {
 			const slotButton = node.querySelector('[data-testid="__palette-slot__"]')


### PR DESCRIPTION
## Summary

In `deletionMode="tooltip"`, `@untemps/svelte-use-tooltip` stamps disclosure semantics onto the `role="presentation"` cell wrappers it is bound to. Because the tooltip is pointer-only (`showOn: ['mouseenter']`), these attributes announce, on presentational cells, an interaction that keyboard and assistive-technology users can never perform there — the keyboard delete path is the listbox-level <kbd>Delete</kbd>/<kbd>Backspace</kbd> shortcut. This addresses the residual ARIA leak from #223.

Two paths leak:
- **Interactive content (default template)** — the focusable `PaletteTrashButton` makes the library treat the tooltip as an interactive disclosure, so it sets `aria-haspopup="dialog"` and toggles `aria-expanded`.
- **Non-interactive content (custom `tooltipContentSelector` with no focusable element)** — the library instead sets `aria-describedby` on the cell on open.

The `tabindex="0"` half of #223 (per-cell tab stops) was already fixed by #231, which added `tabindex="-1"` to the cells; the library's `#applyTabIndex` no longer overrides it. Only the ARIA leak remained.

## Changes

- `useDeletion.ts` — after creating the deletion tooltip, strip `aria-haspopup`, `aria-expanded` and `aria-describedby` from the cell, and keep stripping via a scoped `MutationObserver` (the library re-applies them on every open). The observer is disconnected when the action is destroyed, so there is no leak across updates or unmount.
- `Palette.test.ts` — two tests: the interactive default path (asserts the attributes are absent at rest and after a hover/unhover cycle, guarded by a `role="dialog"` + `aria-modal` check so it cannot pass vacuously), and the non-interactive custom-template path (asserts `aria-describedby` is stripped on open).

Attributes that must stay — `role="presentation"` and `tabindex="-1"` — are untouched. No public API change.

## Test plan

- [x] `yarn test:ci` — 862 tests pass; `useDeletion.ts` at 100% line coverage
- [x] Both new tests verified red→green (fail without the strip, pass with it)
- [x] `yarn run check` — 0 type errors / warnings
- [x] `yarn lint` — Prettier clean
- [x] `yarn build` + `publint` — All good

Closes #223