### PR TITLE
feat: Error state for async colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ yarn add @untemps/svelte-palette
 |            | `colors`     | object[] or ColorGroup[] | The resulting color list, in its resolved and normalized form.                       |
 |            | `groupIndex` | number                   | Index of the group the color was removed from (grouped mode only).                   |
 |            | `groupName`  | string                   | Name of the group the color was removed from (grouped mode only, when named).        |
+| `onerror`  |              |                          | **Called when an async `colors` source rejects.**                                    |
+|            | `error`      | unknown                  | The rejection reason of the `colors` promise.                                        |
 
 ## Snippets
 
@@ -108,6 +110,7 @@ Snippets replace the Svelte 4 named slots API. Pass them as children of `<Palett
 | `settings`        | Allow to replace the settings panel (see [`PaletteSettingsPanel`](#palettesettingspanel)). See the demo to grab a usage example. | `onClose`                                                                                                                          |
 | `tools`           | Allow to replace the tools panel (see [`PaletteTools`](#palettetools)).                                                          | `isCompact`, `compactColorIndices`, `onSelect`                                                                                     |
 | `loader`          | Allow to replace the loader displayed during the colors async retrieving (see [`PaletteLoader`](#paletteloader)).                | -                                                                                                                                  |
+| `error`           | Allow to replace the error state shown when an async `colors` source rejects (see [`PaletteError`](#paletteerror)).              | `error`                                                                                                                            |
 
 ## Example
 
@@ -161,7 +164,7 @@ Snippets replace the Svelte 4 named slots API. Pass them as children of `<Palett
 
 # Components
 
-The package exports eleven components from its entry point, alongside the [deletion-mode](#deletion-modes) and [tool](#customize-the-tools-panel) enums. [`Palette`](#palette-api) is the top-level component; the others are the primitives it composes, exported so you can build your own snippets (`slot`, `input`, `settings`, `tools`, `loader`) or reuse a single control on its own.
+The package exports twelve components from its entry point, alongside the [deletion-mode](#deletion-modes) and [tool](#customize-the-tools-panel) enums. [`Palette`](#palette-api) is the top-level component; the others are the primitives it composes, exported so you can build your own snippets (`slot`, `input`, `settings`, `tools`, `loader`) or reuse a single control on its own.
 
 ```js
 import {
@@ -173,25 +176,27 @@ import {
 	PaletteCompactToggleButton,
 	PaletteIconButton,
 	PaletteLoader,
+	PaletteError,
 	PaletteSettingsButton,
 	PaletteSettingsPanel,
 	PaletteTools,
 } from '@untemps/svelte-palette'
 ```
 
-| Component                                                   | Purpose                                                                                         |
-| ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| [`Palette`](#palette-api)                                   | The main color-picker component (documented in [Palette API](#palette-api)).                    |
-| [`PaletteSlot`](#paletteslot)                               | A single color slot button as rendered in the grid.                                             |
-| [`PaletteInput`](#paletteinput)                             | The color input used to add a new slot (default `input` snippet).                               |
-| [`PaletteEyeDropperButton`](#paletteeyedropperbutton)       | Button that opens the browser EyeDropper to pick a color from the screen.                       |
-| [`PaletteTrashButton`](#palettetrashbutton)                 | The trash button shown in the deletion tooltip.                                                 |
-| [`PaletteCompactToggleButton`](#palettecompacttogglebutton) | Toggles the palette between compact and full modes.                                             |
-| [`PaletteIconButton`](#paletteiconbutton)                   | The base icon button every toolbar button is built on.                                          |
-| [`PaletteLoader`](#paletteloader)                           | The accessible loader shown while an async `colors` source resolves (default `loader` snippet). |
-| [`PaletteSettingsButton`](#palettesettingsbutton)           | Button that opens the settings panel.                                                           |
-| [`PaletteSettingsPanel`](#palettesettingspanel)             | A panel portalled into the DOM, used to host settings content.                                  |
-| [`PaletteTools`](#palettetools)                             | The tools panel wiring the settings and compact-toggle buttons (default `tools` snippet).       |
+| Component                                                   | Purpose                                                                                           |
+| ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| [`Palette`](#palette-api)                                   | The main color-picker component (documented in [Palette API](#palette-api)).                      |
+| [`PaletteSlot`](#paletteslot)                               | A single color slot button as rendered in the grid.                                               |
+| [`PaletteInput`](#paletteinput)                             | The color input used to add a new slot (default `input` snippet).                                 |
+| [`PaletteEyeDropperButton`](#paletteeyedropperbutton)       | Button that opens the browser EyeDropper to pick a color from the screen.                         |
+| [`PaletteTrashButton`](#palettetrashbutton)                 | The trash button shown in the deletion tooltip.                                                   |
+| [`PaletteCompactToggleButton`](#palettecompacttogglebutton) | Toggles the palette between compact and full modes.                                               |
+| [`PaletteIconButton`](#paletteiconbutton)                   | The base icon button every toolbar button is built on.                                            |
+| [`PaletteLoader`](#paletteloader)                           | The accessible loader shown while an async `colors` source resolves (default `loader` snippet).   |
+| [`PaletteError`](#paletteerror)                             | The accessible error state shown when an async `colors` source rejects (default `error` snippet). |
+| [`PaletteSettingsButton`](#palettesettingsbutton)           | Button that opens the settings panel.                                                             |
+| [`PaletteSettingsPanel`](#palettesettingspanel)             | A panel portalled into the DOM, used to host settings content.                                    |
+| [`PaletteTools`](#palettetools)                             | The tools panel wiring the settings and compact-toggle buttons (default `tools` snippet).         |
 
 Each button component below forwards any extra attributes (`...restProps`) to its underlying `<button>`, so attributes such as `aria-label` or `data-*` pass straight through.
 
@@ -280,6 +285,15 @@ The loader shown while an async `colors` source resolves; it is the default [`lo
 | Prop    | Type   | Default          | Description                                                     |
 | ------- | ------ | ---------------- | --------------------------------------------------------------- |
 | `label` | string | "Loading colors" | Text announced by assistive tech while the palette colors load. |
+
+## PaletteError
+
+The error state shown when an async `colors` source rejects; it is the default [`error`](#snippets) snippet content. It is an assertive live region (`role="alert"`) that announces a headline label and, when the rejection reason yields readable text, the message. Restyle it or supply your own `error` snippet to replace it (see [Use an API to Fill the Palette](#use-an-api-to-fill-the-palette)).
+
+| Prop    | Type    | Default                 | Description                                                               |
+| ------- | ------- | ----------------------- | ------------------------------------------------------------------------- |
+| `error` | unknown | null                    | The rejection reason. Rendered as a message when it yields readable text. |
+| `label` | string  | "Colors failed to load" | Text announced by assistive tech and shown as the headline.               |
 
 ## PaletteSettingsButton
 
@@ -586,20 +600,31 @@ The component displays a customizable loader waiting to the promise to be resolv
 
 The default loader (`PaletteLoader`) is an accessible live region: it exposes a `role="status"` so screen readers announce the loading state, and its spinner is driven by a CSS animation that is disabled under `prefers-reduced-motion: reduce`. When you render `PaletteLoader` directly, its announced text comes from a `label` prop (defaults to `Loading colors`). Through `<Palette>` the default loader announces that English default, so to localize the loading announcement — or to replace the loader entirely — supply your own `loader` snippet.
 
+Network calls fail, so the promise-based pattern should handle rejection too. When the `colors` promise rejects, the palette catches it and renders an error state instead of spinning forever: the bundled [`PaletteError`](#paletteerror) by default, or your own `error` snippet. The rejection reason is also delivered to the `onerror` callback, and supplying a fresh `colors` promise clears the error and returns to the loader.
+
 #### Example
 
 ```svelte
 <script>
 	import { Palette } from '@untemps/svelte-palette'
 
-	const colors = fetch('https://www.colr.org/json/colors/random/30')
-		.then((result) => result.json())
-		.then((result) => result.colors.filter((c) => c.hex?.length).map((c) => `#${c.hex}`))
+	const fetchColors = () =>
+		fetch('https://www.colr.org/json/colors/random/30')
+			.then((result) => result.json())
+			.then((result) => result.colors.filter((c) => c.hex?.length).map((c) => `#${c.hex}`))
+
+	let colors = $state(fetchColors())
 </script>
 
-<Palette {colors}>
+<Palette {colors} onerror={({ error }) => console.error('Palette failed to load', error)}>
 	{#snippet loader()}
 		<p>Loading...</p>
+	{/snippet}
+	{#snippet error({ error })}
+		<div role="alert">
+			<p>Could not load colors: {error.message}</p>
+			<button onclick={() => (colors = fetchColors())}>Retry</button>
+		</div>
 	{/snippet}
 </Palette>
 ```

--- a/src/lib/components/Palette.svelte
+++ b/src/lib/components/Palette.svelte
@@ -17,6 +17,7 @@
 	import PaletteSlot from './PaletteSlot.svelte'
 	import PaletteTrashButton from './PaletteTrashButton.svelte'
 	import PaletteLoader from './PaletteLoader.svelte'
+	import PaletteError from './PaletteError.svelte'
 	import PaletteTools from './PaletteTools.svelte'
 	import PaletteSettingsPanel from './PaletteSettingsPanel.svelte'
 	import PaletteCompactToggleButton from './PaletteCompactToggleButton.svelte'
@@ -34,6 +35,8 @@
 		DeleteEventArgs,
 		DeletionMode,
 		EdgeSlotSnippetProps,
+		ErrorEventArgs,
+		ErrorSnippetProps,
 		HeaderSnippetProps,
 		InputAddEventArgs,
 		InputSnippetProps,
@@ -67,6 +70,7 @@
 		onselect?: (args: SelectEventArgs) => void
 		onadd?: (args: AddEventArgs) => void
 		ondelete?: (args: DeleteEventArgs) => void
+		onerror?: (args: ErrorEventArgs) => void
 		label?: string
 		presentational?: boolean
 		class?: string
@@ -76,6 +80,7 @@
 		slot?: Snippet<[SlotSnippetProps]>
 		afterSlot?: Snippet<[EdgeSlotSnippetProps]>
 		loader?: Snippet
+		error?: Snippet<[ErrorSnippetProps]>
 		footer?: Snippet<[HeaderSnippetProps]>
 		input?: Snippet<[InputSnippetProps]>
 		tools?: Snippet<[ToolsSnippetProps]>
@@ -101,6 +106,7 @@
 		onselect = undefined,
 		onadd = undefined,
 		ondelete = undefined,
+		onerror = undefined,
 		label = 'Color slots',
 		presentational = false,
 		class: className = '',
@@ -110,6 +116,7 @@
 		slot: colorSlot = undefined,
 		afterSlot = undefined,
 		loader = undefined,
+		error = undefined,
 		footer = undefined,
 		input = undefined,
 		tools = undefined,
@@ -121,6 +128,8 @@
 	let _colors = $state<NormalizedColor[] | null>(null)
 	let _fullColors = $state<NormalizedColor[] | null>(null)
 	let _colorGroups = $state<NormalizedColorGroup[] | null>(null)
+	let _error = $state<unknown>(null)
+	let _hasError = $state(false)
 	let _numColumns = $state(untrack(() => numColumns))
 	let _isSettingsOn = $state(false)
 	let _isCompact = $state(untrack(() => isCompact))
@@ -129,6 +138,7 @@
 	let _skipColorsSync = $state(false)
 	let _syncedViewParams: ReturnType<typeof _viewParams> | null = null
 	let _colorsGeneration = 0
+	let _colorsSource: ColorsProp | null = null
 
 	let _inputType = $derived(normalizeInputType(inputType))
 
@@ -167,37 +177,62 @@
 		const _source = colors
 		const _params = _viewParams()
 		const generation = ++_colorsGeneration
+		const _sourceChanged = _source !== _colorsSource
+		_colorsSource = _source
 		if (untrack(() => _skipColorsSync)) {
 			_skipColorsSync = false
 			if (_sameViewParams(_syncedViewParams, _params)) {
 				return
 			}
 		}
-		Promise.resolve(_source).then((results) => {
-			if (generation !== _colorsGeneration) {
-				return
-			}
-			if (!!results) {
+		if (_sourceChanged) {
+			_hasError = false
+			_error = null
+		}
+		Promise.resolve(_source).then(
+			(results) => {
+				if (generation !== _colorsGeneration) {
+					return
+				}
+				if (!!results) {
+					_hasError = false
+					_error = null
+					_focusedIndex = null
+					if (isColorGroups(results)) {
+						const newColorGroups = calculateColorGroups(results, {
+							allowDuplicates: _params.allowDuplicates,
+							maxColors: _params.maxColors,
+						})
+						_colorGroups = newColorGroups
+						_colors = null
+						_fullColors = null
+						const maxGroupLength = newColorGroups.reduce((max, g) => Math.max(max, g.colors.length), 0)
+						_numColumns = calculateNumColumns(maxGroupLength, { numColumns: _params.numColumns })
+					} else {
+						const newColors = calculateColors(results, _params)
+						_colors = newColors
+						_colorGroups = null
+						_fullColors = transformColors(Array.isArray(results) ? results : [])
+						_numColumns = calculateNumColumns(newColors.length, _params)
+					}
+				}
+			},
+			(reason) => {
+				if (generation !== _colorsGeneration) {
+					return
+				}
+				const _wasError = _hasError
+				_hasError = true
+				_error = reason
+				_colors = null
+				_colorGroups = null
+				_fullColors = null
 				_focusedIndex = null
-				if (isColorGroups(results)) {
-					const newColorGroups = calculateColorGroups(results, {
-						allowDuplicates: _params.allowDuplicates,
-						maxColors: _params.maxColors,
-					})
-					_colorGroups = newColorGroups
-					_colors = null
-					_fullColors = null
-					const maxGroupLength = newColorGroups.reduce((max, g) => Math.max(max, g.colors.length), 0)
-					_numColumns = calculateNumColumns(maxGroupLength, { numColumns: _params.numColumns })
-				} else {
-					const newColors = calculateColors(results, _params)
-					_colors = newColors
-					_colorGroups = null
-					_fullColors = transformColors(Array.isArray(results) ? results : [])
-					_numColumns = calculateNumColumns(newColors.length, _params)
+				if (!_wasError) {
+					onerror?.({ error: reason })
 				}
 			}
-		})
+		)
 	})
 
 	let _tools: PaletteToolName[] = $derived([
@@ -705,6 +740,12 @@
 					{@render afterSlot({ selectedColor, transition, isCompact: _isCompact })}
 				{/if}
 			</div>
+		{:else if _hasError}
+			{#if error}
+				{@render error({ error: _error })}
+			{:else}
+				<PaletteError error={_error} />
+			{/if}
 		{:else if loader}
 			{@render loader()}
 		{:else}

--- a/src/lib/components/PaletteError.svelte
+++ b/src/lib/components/PaletteError.svelte
@@ -1,0 +1,75 @@
+<script lang="ts">
+	interface Props {
+		/** The error that caused the async `colors` source to reject. Rendered as a message when it yields readable text. */
+		error?: unknown
+		/** Text announced by assistive tech and shown as the headline when the palette colors fail to load. */
+		label?: string
+	}
+
+	let { error = null, label = 'Colors failed to load' }: Props = $props()
+
+	const _message = $derived.by(() => {
+		if (error == null) {
+			return ''
+		}
+		if (error instanceof Error) {
+			return error.message
+		}
+		if (typeof error === 'string') {
+			return error
+		}
+		if (typeof error === 'number' || typeof error === 'boolean') {
+			return String(error)
+		}
+		const { message, statusText } = error as { message?: unknown; statusText?: unknown }
+		if (typeof message === 'string' && message) {
+			return message
+		}
+		if (typeof statusText === 'string' && statusText) {
+			return statusText
+		}
+		return ''
+	})
+</script>
+
+<div class="palette__error" role="alert">
+	<svg
+		class="palette__error__icon"
+		width="24"
+		height="24"
+		viewBox="0 0 24 24"
+		aria-hidden="true"
+		xmlns="http://www.w3.org/2000/svg"
+	>
+		<circle cx="12" cy="12" r="9.5" fill="none" stroke="currentColor" stroke-width="2" />
+		<path d="M12 7v6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+		<circle cx="12" cy="16.5" r="1.25" fill="currentColor" />
+	</svg>
+	<span class="palette__error__label">{label}</span>
+	{#if _message}
+		<span class="palette__error__message">{_message}</span>
+	{/if}
+</div>
+
+<style>
+	.palette__error {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 0.4rem;
+		text-align: center;
+		color: #c0392b;
+		font-family: inherit;
+	}
+
+	.palette__error__label {
+		font-size: 0.875rem;
+		font-weight: 600;
+	}
+
+	.palette__error__message {
+		font-size: 0.75rem;
+		color: #595959;
+		word-break: break-word;
+	}
+</style>

--- a/src/lib/components/__tests__/Palette.test.ts
+++ b/src/lib/components/__tests__/Palette.test.ts
@@ -85,6 +85,173 @@ test('Discards a stale async colors promise that settles after a newer one', asy
 	expect(slots.map((slot) => slot.getAttribute('aria-label'))).toEqual(['#111', '#222'])
 })
 
+test('Renders the default error state when the async colors promise rejects', async () => {
+	let rejectColors!: (reason?: unknown) => void
+	const colors = new Promise<string[]>((_, reject) => (rejectColors = reject))
+	setup(Palette, { props: { colors } })
+
+	expect(await screen.findByRole('status')).toBeInTheDocument()
+	expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+
+	rejectColors(new Error('Network down'))
+
+	const alert = await screen.findByRole('alert')
+	expect(alert).toHaveTextContent('Colors failed to load')
+	expect(alert).toHaveTextContent('Network down')
+	expect(screen.queryByRole('status')).not.toBeInTheDocument()
+	expect(screen.queryAllByTestId('__palette-slot__')).toHaveLength(0)
+})
+
+test('Surfaces an error state even when the rejection reason is falsy', async () => {
+	let rejectColors!: (reason?: unknown) => void
+	const colors = new Promise<string[]>((_, reject) => (rejectColors = reject))
+	setup(Palette, { props: { colors } })
+
+	rejectColors(undefined)
+
+	const alert = await screen.findByRole('alert')
+	expect(alert).toHaveTextContent('Colors failed to load')
+	expect(screen.queryByRole('status')).not.toBeInTheDocument()
+})
+
+test('Invokes onerror with the rejection reason', async () => {
+	const onerror = vi.fn()
+	let rejectColors!: (reason?: unknown) => void
+	const colors = new Promise<string[]>((_, reject) => (rejectColors = reject))
+	setup(Palette, { props: { colors, onerror } })
+
+	const reason = new Error('boom')
+	rejectColors(reason)
+
+	await waitFor(() => expect(onerror).toHaveBeenCalledTimes(1))
+	expect(onerror).toHaveBeenCalledWith({ error: reason })
+})
+
+test('Renders a custom error snippet in place of the default error state', async () => {
+	const errorSnippet = createRawSnippet((getProps) => ({
+		render: () => `<p data-testid="__custom-error__">${(getProps().error as Error).message}</p>`,
+	}))
+	let rejectColors!: (reason?: unknown) => void
+	const colors = new Promise<string[]>((_, reject) => (rejectColors = reject))
+	setup(Palette, { props: { colors, error: errorSnippet } })
+
+	rejectColors(new Error('Custom failure'))
+
+	const custom = await screen.findByTestId('__custom-error__')
+	expect(custom).toHaveTextContent('Custom failure')
+	expect(screen.queryByText('Colors failed to load')).not.toBeInTheDocument()
+})
+
+test('Clears the error state when a fresh colors promise resolves', async () => {
+	let rejectColors!: (reason?: unknown) => void
+	const failing = new Promise<string[]>((_, reject) => (rejectColors = reject))
+	const { component } = setup(PaletteReactive, { props: { initialColors: failing } })
+
+	rejectColors(new Error('temporary'))
+	await screen.findByRole('alert')
+
+	component.setColors(Promise.resolve(['#111', '#222']))
+
+	await waitFor(() => expect(screen.getAllByTestId('__palette-slot__')).toHaveLength(2))
+	expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+})
+
+test('Notifies onerror once per failed source, not on later view-param changes', async () => {
+	const onerror = vi.fn()
+	let rejectColors!: (reason?: unknown) => void
+	const failing = new Promise<string[]>((_, reject) => (rejectColors = reject))
+	const { component } = setup(PaletteReactive, { props: { initialColors: failing, onerror } })
+
+	rejectColors(new Error('once'))
+	await screen.findByRole('alert')
+	expect(onerror).toHaveBeenCalledTimes(1)
+
+	component.setIsCompact(true)
+	await tick()
+	await tick()
+	expect(onerror).toHaveBeenCalledTimes(1)
+})
+
+test('Notifies onerror when a view param changes while the rejection is still pending', async () => {
+	const onerror = vi.fn()
+	let rejectColors!: (reason?: unknown) => void
+	const failing = new Promise<string[]>((_, reject) => (rejectColors = reject))
+	const { component } = setup(PaletteReactive, { props: { initialColors: failing, onerror } })
+
+	await tick()
+	component.setIsCompact(true)
+	await tick()
+
+	rejectColors(new Error('late'))
+	await waitFor(() => expect(onerror).toHaveBeenCalledTimes(1))
+	expect(await screen.findByRole('alert')).toBeInTheDocument()
+})
+
+test('Replaces a resolved palette with the error state when a new colors promise rejects', async () => {
+	let rejectColors!: (reason?: unknown) => void
+	const { component } = setup(PaletteReactive, { props: { initialColors: ['#a00', '#0b0', '#00c'] } })
+
+	expect(await screen.findAllByTestId('__palette-slot__')).toHaveLength(3)
+
+	const failing = new Promise<string[]>((_, reject) => (rejectColors = reject))
+	component.setColors(failing)
+	rejectColors(new Error('refetch failed'))
+
+	await screen.findByRole('alert')
+	expect(screen.queryAllByTestId('__palette-slot__')).toHaveLength(0)
+})
+
+test('Shows the loader again while a retry promise is pending, clearing the previous error', async () => {
+	let rejectColors!: (reason?: unknown) => void
+	const failing = new Promise<string[]>((_, reject) => (rejectColors = reject))
+	const { component } = setup(PaletteReactive, { props: { initialColors: failing } })
+
+	rejectColors(new Error('first failure'))
+	await screen.findByRole('alert')
+
+	let resolveRetry!: (value: string[]) => void
+	const retry = new Promise<string[]>((resolve) => (resolveRetry = resolve))
+	component.setColors(retry)
+
+	await waitFor(() => expect(screen.getByRole('status')).toBeInTheDocument())
+	expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+
+	resolveRetry(['#111', '#222'])
+	await waitFor(() => expect(screen.getAllByTestId('__palette-slot__')).toHaveLength(2))
+})
+
+test('Discards a stale rejecting colors promise that settles after a newer one', async () => {
+	const onerror = vi.fn()
+	let rejectStale!: (reason?: unknown) => void
+	let resolveFresh!: (value: string[]) => void
+	const stalePromise = new Promise<string[]>((_, reject) => (rejectStale = reject))
+	const freshPromise = new Promise<string[]>((resolve) => (resolveFresh = resolve))
+
+	const { component } = setup(PaletteReactive, {
+		props: { initialColors: stalePromise, onerror },
+	})
+
+	await tick()
+	expect(screen.queryAllByTestId('__palette-slot__')).toHaveLength(0)
+
+	component.setColors(freshPromise)
+	await tick()
+
+	resolveFresh(['#111', '#222'])
+	await waitFor(() => expect(screen.getAllByTestId('__palette-slot__')).toHaveLength(2))
+
+	rejectStale(new Error('stale failure'))
+	await stalePromise.catch(() => {})
+	await tick()
+	await tick()
+
+	expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+	expect(onerror).not.toHaveBeenCalled()
+	const slots = screen.getAllByTestId('__palette-slot__')
+	expect(slots).toHaveLength(2)
+	expect(slots.map((slot) => slot.getAttribute('aria-label'))).toEqual(['#111', '#222'])
+})
+
 test('Triggers select with color', async () => {
 	let cells,
 		cell = null

--- a/src/lib/components/__tests__/PaletteError.test.ts
+++ b/src/lib/components/__tests__/PaletteError.test.ts
@@ -1,0 +1,50 @@
+import { render, screen } from '@testing-library/svelte/svelte5'
+
+import PaletteError from '../PaletteError.svelte'
+
+test('Exposes an assertive live region', () => {
+	render(PaletteError)
+	expect(screen.getByRole('alert')).toBeInTheDocument()
+})
+
+test('Announces the default error label', () => {
+	render(PaletteError)
+	expect(screen.getByRole('alert')).toHaveTextContent('Colors failed to load')
+})
+
+test('Announces a custom error label', () => {
+	render(PaletteError, { props: { label: 'Échec du chargement des couleurs' } })
+	expect(screen.getByRole('alert')).toHaveTextContent('Échec du chargement des couleurs')
+})
+
+test('Renders the message of an Error instance', () => {
+	render(PaletteError, { props: { error: new Error('Failed to fetch') } })
+	expect(screen.getByRole('alert')).toHaveTextContent('Failed to fetch')
+})
+
+test('Renders a non-Error rejection reason as text', () => {
+	render(PaletteError, { props: { error: 'Network down' } })
+	expect(screen.getByRole('alert')).toHaveTextContent('Network down')
+})
+
+test('Renders only the label when no error is provided', () => {
+	const { container } = render(PaletteError)
+	expect(container.querySelector('.palette__error__message')).not.toBeInTheDocument()
+})
+
+test('Does not surface "[object Object]" for an opaque object reason', () => {
+	const { container } = render(PaletteError, { props: { error: { code: 500 } } })
+	expect(screen.getByRole('alert')).not.toHaveTextContent('[object Object]')
+	expect(container.querySelector('.palette__error__message')).not.toBeInTheDocument()
+})
+
+test('Surfaces the statusText of a response-like reason', () => {
+	render(PaletteError, { props: { error: { status: 503, statusText: 'Service Unavailable' } } })
+	expect(screen.getByRole('alert')).toHaveTextContent('Service Unavailable')
+})
+
+test('Hides the error icon from assistive tech', () => {
+	const { container } = render(PaletteError)
+	const icon = container.querySelector('.palette__error__icon')
+	expect(icon).toHaveAttribute('aria-hidden', 'true')
+})

--- a/src/lib/components/__tests__/PaletteReactive.test.svelte
+++ b/src/lib/components/__tests__/PaletteReactive.test.svelte
@@ -5,7 +5,7 @@
 
 	import { NONE } from '../../enums/PaletteDeletionMode'
 
-	import type { ColorsProp, DeleteEventArgs, DeletionMode } from '../../types'
+	import type { ColorsProp, DeleteEventArgs, DeletionMode, ErrorEventArgs } from '../../types'
 
 	let {
 		initialColors,
@@ -18,6 +18,7 @@
 		initialShowInput = false,
 		deletionMode = NONE,
 		ondelete = undefined,
+		onerror = undefined,
 	}: {
 		initialColors: ColorsProp
 		initialIsCompact?: boolean
@@ -29,6 +30,7 @@
 		initialShowInput?: boolean
 		deletionMode?: DeletionMode
 		ondelete?: (args: DeleteEventArgs) => void
+		onerror?: (args: ErrorEventArgs) => void
 	} = $props()
 
 	let colors = $state<ColorsProp | null>(untrack(() => initialColors))
@@ -62,4 +64,5 @@
 	{showInput}
 	{deletionMode}
 	{ondelete}
+	{onerror}
 />

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -6,6 +6,7 @@ export { default as PaletteTrashButton } from './components/PaletteTrashButton.s
 export { default as PaletteCompactToggleButton } from './components/PaletteCompactToggleButton.svelte'
 export { default as PaletteIconButton } from './components/PaletteIconButton.svelte'
 export { default as PaletteLoader } from './components/PaletteLoader.svelte'
+export { default as PaletteError } from './components/PaletteError.svelte'
 export { default as PaletteSettingsButton } from './components/PaletteSettingsButton.svelte'
 export { default as PaletteSettingsPanel } from './components/PaletteSettingsPanel.svelte'
 export { default as PaletteTools } from './components/PaletteTools.svelte'

--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -113,10 +113,11 @@ export interface DeleteEventArgs {
 }
 
 /**
- * Argument passed to the `onerror` callback when the eye dropper fails or is dismissed.
+ * Argument passed to an `onerror` callback carrying the underlying error. Used by the eye dropper when the
+ * EyeDropper API fails or is dismissed, and by the palette when an async `colors` source rejects.
  */
 export interface ErrorEventArgs {
-	/** The error thrown by the EyeDropper API. */
+	/** The error thrown by the EyeDropper API, or the rejection reason of an async `colors` source. */
 	error: unknown
 }
 
@@ -216,4 +217,13 @@ export interface ToolsSnippetProps {
 export interface SettingsSnippetProps {
 	/** Closes the settings panel. */
 	onClose: () => void
+}
+
+/**
+ * Properties passed to the `error` snippet that replaces the default error state shown when an async
+ * `colors` source rejects.
+ */
+export interface ErrorSnippetProps {
+	/** The rejection reason of the async `colors` source. */
+	error: unknown
 }

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -25,6 +25,7 @@
 		<HeaderNavItem href="/example3" text="Example 3" />
 		<HeaderNavItem href="/example4" text="Example 4" />
 		<HeaderNavItem href="/example5" text="Example 5" />
+		<HeaderNavItem href="/example6" text="Example 6" />
 	</HeaderNav>
 </Header>
 
@@ -35,6 +36,7 @@
 		<SideNavLink href="/example3" text="Example 3" />
 		<SideNavLink href="/example4" text="Example 4" />
 		<SideNavLink href="/example5" text="Example 5" />
+		<SideNavLink href="/example6" text="Example 6" />
 	</SideNavItems>
 </SideNav>
 

--- a/src/routes/example6/+page.svelte
+++ b/src/routes/example6/+page.svelte
@@ -1,0 +1,204 @@
+<script lang="ts">
+	import { Palette } from '$lib'
+
+	import type { ColorsProp } from '$lib/types'
+
+	const _palette = ['#2ec4b6', '#e71d36', '#ff9f1c', '#011627', '#41ead4', '#f71735', '#3a86ff', '#8338ec']
+
+	const _fetchColors = (shouldFail: boolean): Promise<string[]> =>
+		new Promise((resolve, reject) =>
+			setTimeout(
+				() =>
+					shouldFail ? reject(new Error('The color service is unavailable (HTTP 503)')) : resolve(_palette),
+				900
+			)
+		)
+
+	let colors = $state<ColorsProp | null>(_fetchColors(true))
+	let selectedColor = $state<string | null>(null)
+	let lastError = $state<string | null>(null)
+
+	const _failingSource = _fetchColors(true)
+
+	const _loadFailing = () => {
+		lastError = null
+		colors = _fetchColors(true)
+	}
+
+	const _loadSucceeding = () => {
+		lastError = null
+		colors = _fetchColors(false)
+	}
+</script>
+
+<main class="example6" style="--bgColor:{selectedColor ?? '#1b1b1b'}">
+	<h1 class="title">Async Colors &amp; Error State</h1>
+	<p class="intro">
+		The <code>colors</code> prop accepts a promise. While it is pending the palette shows the loader; if it rejects,
+		the palette shows an error state — through the <code>error</code> snippet and the
+		<code>onerror</code> callback — instead of spinning forever. Retrying with a fresh promise clears the error.
+	</p>
+
+	<div class="controls">
+		<button type="button" onclick={_loadSucceeding}>Fetch colors (succeeds)</button>
+		<button type="button" onclick={_loadFailing}>Fetch colors (fails)</button>
+	</div>
+
+	<div class="content">
+		<Palette
+			class="palette__custom"
+			{colors}
+			bind:selectedColor
+			numColumns={4}
+			onerror={({ error }) => (lastError = error instanceof Error ? error.message : String(error))}
+		>
+			{#snippet error({ error })}
+				<div class="error">
+					<p class="error__message">
+						{error instanceof Error ? error.message : 'Unable to load the colors.'}
+					</p>
+					<button type="button" class="error__retry" onclick={_loadSucceeding}>Retry</button>
+				</div>
+			{/snippet}
+		</Palette>
+	</div>
+
+	<div class="status" data-testid="__example-error__">
+		{#if lastError}
+			<span class="status__label">onerror</span>
+			<span class="status__value">{lastError}</span>
+		{:else}
+			<span class="status__hint">No error reported yet — try the “fails” button above.</span>
+		{/if}
+	</div>
+
+	<p class="intro intro--muted">
+		Omitting the <code>error</code> snippet renders the bundled <code>PaletteError</code> component instead:
+	</p>
+	<div class="content">
+		<Palette class="palette__custom palette__custom--default" colors={_failingSource} numColumns={4} />
+	</div>
+</main>
+
+<style>
+	.example6 {
+		min-height: 100%;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 1.25rem;
+		padding: 2.5rem 1.5rem;
+		font-family: Helvetica, sans-serif;
+		color: #f5f5f5;
+		background-color: var(--bgColor);
+		transition: background-color 0.4s ease;
+	}
+
+	.title {
+		margin: 0;
+		font-size: 1.75rem;
+		text-align: center;
+	}
+
+	.intro {
+		max-width: 42rem;
+		margin: 0;
+		text-align: center;
+		line-height: 1.5;
+	}
+
+	.intro--muted {
+		margin-top: 1rem;
+		opacity: 0.85;
+	}
+
+	.intro code {
+		padding: 0.05rem 0.3rem;
+		font-size: 0.85em;
+		background-color: rgba(255, 255, 255, 0.14);
+		border-radius: 0.2rem;
+	}
+
+	.controls {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.75rem;
+		justify-content: center;
+	}
+
+	.controls button {
+		padding: 0.5rem 1rem;
+		font: inherit;
+		font-size: 0.875rem;
+		color: #1b1b1b;
+		background-color: #f5f5f5;
+		border: none;
+		border-radius: 0.3rem;
+		cursor: pointer;
+	}
+
+	.controls button:hover {
+		background-color: #fff;
+	}
+
+	.content {
+		width: 100%;
+		max-width: 26rem;
+	}
+
+	.example6 :global(.palette[data-palette].palette__custom) {
+		border-radius: 0.5rem;
+		overflow: hidden;
+	}
+
+	.example6 :global(.palette__custom--default) {
+		background-color: #fff;
+	}
+
+	.error {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 0.6rem;
+		padding: 0.5rem;
+		text-align: center;
+		color: #c0392b;
+	}
+
+	.error__message {
+		margin: 0;
+		font-size: 0.875rem;
+		font-weight: 600;
+	}
+
+	.error__retry {
+		padding: 0.35rem 0.9rem;
+		font: inherit;
+		font-size: 0.8rem;
+		color: #fff;
+		background-color: #c0392b;
+		border: none;
+		border-radius: 0.3rem;
+		cursor: pointer;
+	}
+
+	.status {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		min-height: 1.5rem;
+		font-size: 0.8rem;
+	}
+
+	.status__label {
+		padding: 0.1rem 0.4rem;
+		font-family: monospace;
+		color: #1b1b1b;
+		background-color: #ffb3a7;
+		border-radius: 0.2rem;
+	}
+
+	.status__hint {
+		opacity: 0.7;
+	}
+</style>


### PR DESCRIPTION
## Summary

Adds an error state for a rejected async `colors` promise. A failed fetch no longer degrades into an indefinite spinner: the palette renders an error state (the new `PaletteError` by default, or an `error` snippet) and notifies the host through a new `onerror` callback. Retrying with a fresh `colors` promise clears the failure.

## Changes

- **`PaletteError`** — new accessible default error component (`role="alert"`), exported from the entry point. Shows a headline label and, when the reason yields readable text, a message; opaque object reasons never surface as `[object Object]`.
- **`Palette`** — the colors resolver gains a rejection path; new optional `error` snippet and `onerror` callback. The handler respects the concurrent-promise generation guard (a stale rejection cannot clobber a newer source) and fires `onerror` once per failure — even when the resolver re-runs on a view-param change while the rejection is still pending.
- **Types** — new `ErrorSnippetProps`; `ErrorEventArgs` generalized (now shared with the eye dropper).
- **Demo** — Example 6 demonstrates loader → error → retry, `onerror`, the `error` snippet, and the default `PaletteError`.
- **Docs** — README: `error` snippet and Palette-level `onerror` rows, a `PaletteError` section, updated component list, and an extended "Use an API to Fill the Palette" recipe showing the failure path.

## Behavioral change (non-breaking)

A rejected `colors` promise was previously an uncaught global `unhandledrejection`. It is now caught and turned into component state, with `onerror` as the replacement hook, and the indefinite spinner becomes an error state. A host relying on a global `unhandledrejection` / `window.onerror` handler to notice palette fetch failures should switch to `onerror`. `error` / `onerror` are additive and optional — no existing prop, snippet, or callback changes.

## Test plan

- [ ] A rejecting `colors` promise renders the default error state; the loader is gone; no slots are painted
- [ ] The `error` snippet overrides the default; `onerror` fires once with the rejection reason
- [ ] A fresh resolving promise clears the error (retry); the loader returns while the retry is pending
- [ ] A stale rejection settling after a newer source neither clobbers the result nor notifies
- [ ] `onerror` still fires when a view param changes while the rejection is still pending
- [ ] Falsy / opaque rejection reasons still show the error state (no `[object Object]`)
- [ ] `yarn test:ci`, `yarn run check`, `yarn build`, `yarn lint` all green

Closes #204