### PR TITLE
docs: Correct the documented default deletion tooltip class

### DIFF
--- a/README.md
+++ b/README.md
@@ -566,10 +566,10 @@ To do so, set a **global** class name to the `tooltipClassName` prop.
 
 > As the tooltip is interactive, make sure you define a sufficient hover area that allow to access the content of the tooltip before the leave event is triggered.
 
-If you ignore that prop, a default class is used.
+If you ignore that prop, the tooltip keeps the default class names from [@untemps/svelte-use-tooltip](https://github.com/untemps/svelte-use-tooltip): `__tooltip __tooltip-top`.
 
-> Please note that the default class name is `__tooltip__default`.
-> Provide a different class name otherwise the default class would have the precedence over the custom one.
+> Please note that `tooltipClassName` **replaces** the default class names rather than adding to them.
+> The default tooltip styles (background, padding, border radius and the arrow drawn by `.__tooltip::after`) are therefore dropped when you pass a custom class, so your class must provide its own styling.
 
 #### Example
 


### PR DESCRIPTION
## Summary

The **Deletion Tooltip Class** section of the README documented a default tooltip class name (`__tooltip__default`) that exists nowhere in the code, and stated the class-precedence rule backwards. This corrects both to match the actual behavior of `@untemps/svelte-use-tooltip`.

`__tooltip__default` occurred exactly once in the whole repo — on the README line itself; no code path ever produces it.

## Verified behavior

Confirmed against the installed `@untemps/svelte-use-tooltip@4.0.0`:

- `useDeletion` forwards `tooltipClassName` straight through as the dependency's `containerClassName` and never passes a `position`, so the default is `__tooltip __tooltip-top` (`#position` defaults to `'top'`).
- The class is assigned as `containerClassName || \`__tooltip __tooltip-${position}\``, i.e. a custom class **replaces** the default class list rather than competing with it. The default can never "have the precedence over the custom one"; instead, passing a custom class drops all default styling (background, padding, border radius, and the `.__tooltip::after` arrow).

## Changes

- Replace the inaccurate default-class name and the inverted precedence warning with an accurate description: the default is `__tooltip __tooltip-top`, and `tooltipClassName` **replaces** the defaults (so a custom class must provide its own styling).
- The existing example already restyles the tooltip from scratch and stays valid under the corrected wording.
- Cross-checked the `tooltipClassName` row in the props table — it already reads accurately and needs no change.

## Test plan

- [ ] Read the corrected **Deletion Tooltip Class** section and confirm it matches the installed `@untemps/svelte-use-tooltip` behavior.
- [ ] Confirm the example at the end of the section still renders a styled tooltip.

Closes #205