### PR TITLE
feat: CSS custom property theming and dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,6 +597,22 @@ Your own token overrides win over the built-in themes, so you can fine-tune eith
 <Palette {colors} data-palette-theme="dark" style="--palette-surface: #101418;" />
 ```
 
+### Box Sizing
+
+The palette applies a `box-sizing: border-box` reset **scoped to itself and its descendants** (`.palette, .palette *`) — it no longer resets the whole host document. This keeps the library from silently altering your app's box model, but it has two consequences:
+
+- **Migrating from a previous version:** earlier releases reset every element on the page (`* { box-sizing: border-box }`). If your app was relying on that inherited reset, add your own once at the app level:
+
+    ```css
+    *,
+    *::before,
+    *::after {
+    	box-sizing: border-box;
+    }
+    ```
+
+- **Using the exported sub-components standalone:** a sub-component (e.g. `PaletteSlot`, `PaletteIconButton`, `PaletteInput`) mounted _outside_ a `Palette` root does not inherit the reset, so under the host's default `content-box` its border adds to its fixed size (a slot renders `1rem + 2px` rather than `1rem`). Wrap it in an element with `box-sizing: border-box` if you need pixel-exact sizing.
+
 ### Root Tag Class
 
 > The [token API](#theming-with-css-custom-properties) above is the recommended way to restyle the palette. Reach for the `:global()` overrides below only for things the tokens do not expose (layout, geometry, a specific element). They couple you to internal BEM class names, which are not a stable contract.

--- a/README.md
+++ b/README.md
@@ -238,9 +238,9 @@ The color input used to add a new color to the palette. Implements the default [
 
 Button that opens the browser [EyeDropper API](#eyedropper-api-support) to pick a color from the screen. It always renders when mounted directly — the default input is what hides it when the API is unavailable — so guard on EyeDropper support yourself when using it standalone.
 
-| Prop              | Type   | Default                        | Description                                 |
-| ----------------- | ------ | ------------------------------ | ------------------------------------------- |
-| `eyeDropperLabel` | string | "Pick a color from the screen" | Accessible name of the eye-dropper button.  |
+| Prop              | Type   | Default                        | Description                                |
+| ----------------- | ------ | ------------------------------ | ------------------------------------------ |
+| `eyeDropperLabel` | string | "Pick a color from the screen" | Accessible name of the eye-dropper button. |
 
 | Callback  | Arguments   | Description                                         |
 | --------- | ----------- | --------------------------------------------------- |
@@ -310,9 +310,9 @@ The error state shown when an async `colors` source rejects; it is the default [
 
 Button that opens the settings panel. Renders the settings icon with a `"Go to settings"` accessible name.
 
-| Prop            | Type   | Default          | Description                              |
-| --------------- | ------ | ---------------- | ---------------------------------------- |
-| `settingsLabel` | string | "Go to settings" | Accessible name of the settings button.  |
+| Prop            | Type   | Default          | Description                             |
+| --------------- | ------ | ---------------- | --------------------------------------- |
+| `settingsLabel` | string | "Go to settings" | Accessible name of the settings button. |
 
 | Callback  | Arguments    | Description                        |
 | --------- | ------------ | ---------------------------------- |
@@ -508,12 +508,97 @@ If you replace a region with your own snippet (`loader`, `error`, `input`, `tool
 
 # Styles
 
+### Theming with CSS Custom Properties
+
+The palette is themed through a set of `--palette-*` custom properties declared on its root element. Because custom properties inherit through the subtree and pierce Svelte's style scoping, you override them with an ordinary inline `style` — or any CSS rule that targets the root — with no `:global()`, no `!important`, and no dependency on internal class names.
+
+`<Palette>` forwards `style` and any other extra attributes (`...restProps`) to its root `<div>`, so inline custom properties and `data-*` attributes pass straight through:
+
+```svelte
+<script>
+	import { Palette } from '@untemps/svelte-palette'
+
+	const colors = ['#865C54', '#8F5447', '#A65846', '#A9715E', '#AD8C72']
+</script>
+
+<!-- Inline, per instance -->
+<Palette {colors} style="--palette-surface: #fffaf0; --palette-radius: 0.75rem;" />
+```
+
+Or from a stylesheet, by passing a class and setting the tokens on it:
+
+```svelte
+<Palette {colors} class="brand-palette" />
+
+<style>
+	:global(.brand-palette) {
+		--palette-surface: #fffaf0;
+		--palette-radius: 0.75rem;
+	}
+</style>
+```
+
+#### Tokens
+
+Every value falls back to its default, so a palette with no tokens set renders exactly as before.
+
+| Custom property           | Default (light)          | Dark theme                 | Controls                                                     |
+| ------------------------- | ------------------------ | -------------------------- | ------------------------------------------------------------ |
+| `--palette-surface`       | `#fafafa`                | `#1e1e1e`                  | Palette and toolbar-button background                        |
+| `--palette-text`          | `black`                  | `#ededed`                  | Foreground text                                              |
+| `--palette-border`        | `#e5e5e5`                | `#3a3a3a`                  | Control borders and the active toolbar-button fill           |
+| `--palette-divider`       | `#e9e9e9`                | `#3a3a3a`                  | Divider lines above the input and tools                      |
+| `--palette-icon`          | `#646464`                | `#d0d0d0`                  | Toolbar icon stroke                                          |
+| `--palette-icon-disabled` | `#bdbdbd`                | `#6a6a6a`                  | Disabled toolbar icon stroke                                 |
+| `--palette-radius`        | `0.3rem`                 | —                          | Corner radius of buttons and the input                       |
+| `--palette-font-family`   | `Helvetica, sans-serif`  | —                          | Hex input font family                                        |
+| `--palette-slot-size`     | `1rem`                   | —                          | Diameter of a color slot                                     |
+| `--palette-slot-border`   | `rgba(0, 0, 0, 0.2)`     | `rgba(255, 255, 255, .2)`  | Slot outline                                                 |
+| `--palette-slot-empty`    | `#aaa`                   | `#777`                     | Empty / transparent slot outline and diagonal                |
+| `--palette-slot-ring`     | `#9e9e9e`                | `#6a6a6a`                  | Ring around the selected slot                                |
+| `--palette-input-surface` | `rgba(255, 255, 255, 1)` | `#2a2a2a`                  | Hex input background                                         |
+| `--palette-input-text`    | `rgba(0, 0, 0, 0.6)`     | `rgba(255, 255, 255, .75)` | Hex input text                                               |
+| `--palette-error`         | `#c0392b`                | `#ff6b5e`                  | Error headline and icon                                      |
+| `--palette-error-message` | `#595959`                | `#b0b0b0`                  | Error detail message                                         |
+| `--palette-focus-ring`    | `#1a1a1a`                | `#f0f0f0`                  | Keyboard focus outline (see [Focus Outline](#focus-outline)) |
+
+> `--palette-focus-ring` is themeable so the focus outline can stay visible in dark mode, but its light and dark defaults are chosen for WCAG-compliant contrast against the palette surface. Override it only with a value that preserves sufficient contrast.
+
+### Dark Mode
+
+The palette ships an automatic dark theme. When the host OS prefers a dark color scheme (`prefers-color-scheme: dark`), the `--palette-*` tokens remap to a dark set. Hosts stay in control through the `data-palette-theme` attribute (also forwarded to the root):
+
+| `data-palette-theme` | Result                             |
+| -------------------- | ---------------------------------- |
+| absent / `auto`      | Follows the OS preference          |
+| `light`              | Always light, even under a dark OS |
+| `dark`               | Always dark, even under a light OS |
+
+```svelte
+<!-- Follow the OS (default) -->
+<Palette {colors} />
+
+<!-- Force light regardless of the OS -->
+<Palette {colors} data-palette-theme="light" />
+
+<!-- Force dark regardless of the OS -->
+<Palette {colors} data-palette-theme="dark" />
+```
+
+Your own token overrides win over the built-in themes, so you can fine-tune either one:
+
+```svelte
+<Palette {colors} data-palette-theme="dark" style="--palette-surface: #101418;" />
+```
+
 ### Root Tag Class
+
+> The [token API](#theming-with-css-custom-properties) above is the recommended way to restyle the palette. Reach for the `:global()` overrides below only for things the tokens do not expose (layout, geometry, a specific element). They couple you to internal BEM class names, which are not a stable contract.
 
 You can style the component by passing a class down to the root tag (`div`).
 
 - Flag the class as global to make it available in the Palette component
-- Prefix your class with `.palette[data-palette]` to give precedence over the default one or mark each style with `!important` (not recommanded)
+- Prefix your class with `.palette[data-palette]` to give precedence over the default one or mark each style with `!important` (not recommended)
 
 #### Example
 
@@ -551,10 +636,10 @@ When colors are grouped, each group keeps its own `.palette__cells` grid instead
 
 Every focusable control in the palette shares the same keyboard focus ring: a `2px` solid outline with a `2px` offset, shown only on `:focus-visible` (keyboard interaction, not mouse click). This covers the color slots, the toolbar icon buttons (settings, compact toggle, eye dropper, input submit) and the deletion trash button.
 
-The ring color is fixed for a consistent, WCAG-compliant contrast rather than themeable:
+The ring color comes from the [`--palette-focus-ring`](#tokens) token, whose light and dark defaults are tuned for WCAG-compliant contrast against the palette surface:
 
-- **Dark `#1a1a1a`** on the light `#fafafa` palette and toolbar surfaces. For a slot the ring is drawn in the 2px offset gap over the palette background, so it stays ~17:1 whatever the swatch color.
-- **Light `#fff`** on the dark deletion tooltip that hosts the trash button (~21:1).
+- **Dark `#1a1a1a`** on the light surface, flipping to **light `#f0f0f0`** in the dark theme. For a slot the ring is drawn in the 2px offset gap over the palette surface, so it stays high-contrast whatever the slot color.
+- The deletion trash button keeps a fixed **light `#fff`** ring because its tooltip is dark in every theme.
 
 Under Windows High Contrast (`forced-colors`), the ring switches to the system `Highlight` color.
 

--- a/README.md
+++ b/README.md
@@ -651,6 +651,8 @@ To do so, set a **global** class name to the `tooltipClassName` prop.
 
 > As the tooltip is interactive, make sure you define a sufficient hover area that allow to access the content of the tooltip before the leave event is triggered.
 
+> The tooltip is rendered inline within the palette (not portalled to `<body>`), so an ancestor with `overflow: hidden` — for example a wrapper used to clip rounded corners — will clip the tooltip too. Round the palette element itself instead of clipping an outer wrapper, or avoid `overflow: hidden` on ancestors of the palette.
+
 If you ignore that prop, the tooltip keeps the default class names from [@untemps/svelte-use-tooltip](https://github.com/untemps/svelte-use-tooltip): `__tooltip __tooltip-top`.
 
 > Please note that `tooltipClassName` **replaces** the default class names rather than adding to them.

--- a/README.md
+++ b/README.md
@@ -552,6 +552,7 @@ Every value falls back to its default, so a palette with no tokens set renders e
 | `--palette-divider`         | `#e9e9e9`                | `#3a3a3a`                  | Divider lines above the input and tools                      |
 | `--palette-icon`            | `#646464`                | `#d0d0d0`                  | Toolbar icon stroke                                          |
 | `--palette-icon-disabled`   | `#bdbdbd`                | `#6a6a6a`                  | Disabled toolbar icon stroke                                 |
+| `--palette-loader`          | `#ccc`                   | `#555555`                  | Loading spinner arc                                          |
 | `--palette-radius`          | `0.3rem`                 | —                          | Corner radius of buttons and the input                       |
 | `--palette-font-family`     | `Helvetica, sans-serif`  | —                          | Hex input font family                                        |
 | `--palette-slot-size`       | `1rem`                   | —                          | Diameter of a color slot                                     |

--- a/README.md
+++ b/README.md
@@ -510,7 +510,7 @@ If you replace a region with your own snippet (`loader`, `error`, `input`, `tool
 
 ### Theming with CSS Custom Properties
 
-The palette is themed through a set of `--palette-*` custom properties declared on its root element. Because custom properties inherit through the subtree and pierce Svelte's style scoping, you override them with an ordinary inline `style` — or any CSS rule that targets the root — with no `:global()`, no `!important`, and no dependency on internal class names.
+The palette is themed through a set of `--palette-*` custom properties declared on its root element. The defaults are declared at **zero specificity** (via `:where()`), so any ordinary rule that targets the root overrides them — an inline `style`, or a class — with no `!important` and no dependency on internal BEM class names. The tokens inherit through the subtree, so overriding them on the root re-themes the whole palette.
 
 `<Palette>` forwards `style` and any other extra attributes (`...restProps`) to its root `<div>`, so inline custom properties and `data-*` attributes pass straight through:
 
@@ -537,6 +537,8 @@ Or from a stylesheet, by passing a class and setting the tokens on it:
 	}
 </style>
 ```
+
+> The `:global()` here is only needed to pierce Svelte's style scoping so the selector can reach the palette's root from your component — not to win on precedence. A plain class selector already outranks the zero-specificity token defaults.
 
 #### Tokens
 

--- a/README.md
+++ b/README.md
@@ -572,7 +572,7 @@ Every value falls back to its default, so a palette with no tokens set renders e
 
 ### Dark Mode
 
-The palette ships an automatic dark theme. When the host OS prefers a dark color scheme (`prefers-color-scheme: dark`), the `--palette-*` tokens remap to a dark set. Hosts stay in control through the `data-palette-theme` attribute (also forwarded to the root):
+The palette ships an automatic dark theme, built on the CSS [`light-dark()`](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/light-dark) function and `color-scheme`. When the host OS prefers a dark color scheme (`prefers-color-scheme: dark`), the themeable `--palette-*` tokens resolve to a dark set. Hosts stay in control through the `data-palette-theme` attribute (also forwarded to the root):
 
 | `data-palette-theme` | Result                             |
 | -------------------- | ---------------------------------- |
@@ -596,6 +596,8 @@ Your own token overrides win over the built-in themes, so you can fine-tune eith
 ```svelte
 <Palette {colors} data-palette-theme="dark" style="--palette-surface: #101418;" />
 ```
+
+> Dark mode relies on `light-dark()` ([Baseline 2024](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/light-dark#browser_compatibility)). On older browsers that lack it, the palette gracefully stays light regardless of the OS or `data-palette-theme` — every other feature is unaffected. Your own token overrides still apply, so you can theme those browsers explicitly.
 
 ### Box Sizing
 

--- a/README.md
+++ b/README.md
@@ -598,6 +598,8 @@ Your own token overrides win over the built-in themes, so you can fine-tune eith
 <Palette {colors} data-palette-theme="dark" style="--palette-surface: #101418;" />
 ```
 
+> If you override the tokens to a **light** appearance but leave `data-palette-theme` on `auto`, the palette still adopts the OS `color-scheme` — so under a dark OS the browser-rendered internals of the hex input (caret, text selection, autofill) resolve dark against your light surface. Pair a light token override with `data-palette-theme="light"` (and a dark one with `data-palette-theme="dark"`) to keep the `color-scheme` in step with your colors.
+
 > Dark mode relies on `light-dark()` ([Baseline 2024](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/light-dark#browser_compatibility)). On older browsers that lack it, the palette gracefully stays light regardless of the OS or `data-palette-theme` — every other feature is unaffected. Your own token overrides still apply, so you can theme those browsers explicitly.
 
 ### Box Sizing

--- a/README.md
+++ b/README.md
@@ -542,27 +542,31 @@ Or from a stylesheet, by passing a class and setting the tokens on it:
 
 Every value falls back to its default, so a palette with no tokens set renders exactly as before.
 
-| Custom property           | Default (light)          | Dark theme                 | Controls                                                     |
-| ------------------------- | ------------------------ | -------------------------- | ------------------------------------------------------------ |
-| `--palette-surface`       | `#fafafa`                | `#1e1e1e`                  | Palette and toolbar-button background                        |
-| `--palette-text`          | `black`                  | `#ededed`                  | Foreground text                                              |
-| `--palette-border`        | `#e5e5e5`                | `#3a3a3a`                  | Control borders and the active toolbar-button fill           |
-| `--palette-divider`       | `#e9e9e9`                | `#3a3a3a`                  | Divider lines above the input and tools                      |
-| `--palette-icon`          | `#646464`                | `#d0d0d0`                  | Toolbar icon stroke                                          |
-| `--palette-icon-disabled` | `#bdbdbd`                | `#6a6a6a`                  | Disabled toolbar icon stroke                                 |
-| `--palette-radius`        | `0.3rem`                 | —                          | Corner radius of buttons and the input                       |
-| `--palette-font-family`   | `Helvetica, sans-serif`  | —                          | Hex input font family                                        |
-| `--palette-slot-size`     | `1rem`                   | —                          | Diameter of a color slot                                     |
-| `--palette-slot-border`   | `rgba(0, 0, 0, 0.2)`     | `rgba(255, 255, 255, .2)`  | Slot outline                                                 |
-| `--palette-slot-empty`    | `#aaa`                   | `#777`                     | Empty / transparent slot outline and diagonal                |
-| `--palette-slot-ring`     | `#9e9e9e`                | `#6a6a6a`                  | Ring around the selected slot                                |
-| `--palette-input-surface` | `rgba(255, 255, 255, 1)` | `#2a2a2a`                  | Hex input background                                         |
-| `--palette-input-text`    | `rgba(0, 0, 0, 0.6)`     | `rgba(255, 255, 255, .75)` | Hex input text                                               |
-| `--palette-error`         | `#c0392b`                | `#ff6b5e`                  | Error headline and icon                                      |
-| `--palette-error-message` | `#595959`                | `#b0b0b0`                  | Error detail message                                         |
-| `--palette-focus-ring`    | `#1a1a1a`                | `#f0f0f0`                  | Keyboard focus outline (see [Focus Outline](#focus-outline)) |
+| Custom property             | Default (light)          | Dark theme                 | Controls                                                     |
+| --------------------------- | ------------------------ | -------------------------- | ------------------------------------------------------------ |
+| `--palette-surface`         | `#fafafa`                | `#1e1e1e`                  | Palette and toolbar-button background                        |
+| `--palette-text`            | `black`                  | `#ededed`                  | Foreground text                                              |
+| `--palette-border`          | `#e5e5e5`                | `#3a3a3a`                  | Control borders and the active toolbar-button fill           |
+| `--palette-divider`         | `#e9e9e9`                | `#3a3a3a`                  | Divider lines above the input and tools                      |
+| `--palette-icon`            | `#646464`                | `#d0d0d0`                  | Toolbar icon stroke                                          |
+| `--palette-icon-disabled`   | `#bdbdbd`                | `#6a6a6a`                  | Disabled toolbar icon stroke                                 |
+| `--palette-radius`          | `0.3rem`                 | —                          | Corner radius of buttons and the input                       |
+| `--palette-font-family`     | `Helvetica, sans-serif`  | —                          | Hex input font family                                        |
+| `--palette-slot-size`       | `1rem`                   | —                          | Diameter of a color slot                                     |
+| `--palette-slot-border`     | `rgba(0, 0, 0, 0.2)`     | `rgba(255, 255, 255, .2)`  | Slot outline                                                 |
+| `--palette-slot-empty`      | `#aaa`                   | `#777`                     | Empty / transparent slot outline and diagonal                |
+| `--palette-slot-ring`       | `#9e9e9e`                | `#6a6a6a`                  | Ring around the selected slot                                |
+| `--palette-input-surface`   | `rgba(255, 255, 255, 1)` | `#2a2a2a`                  | Hex input background                                         |
+| `--palette-input-text`      | `rgba(0, 0, 0, 0.6)`     | `rgba(255, 255, 255, .75)` | Hex input text                                               |
+| `--palette-error`           | `#c0392b`                | `#ff6b5e`                  | Error headline and icon                                      |
+| `--palette-error-message`   | `#595959`                | `#b0b0b0`                  | Error detail message                                         |
+| `--palette-focus-ring`      | `#1a1a1a`                | `#f0f0f0`                  | Keyboard focus outline (see [Focus Outline](#focus-outline)) |
+| `--palette-tooltip-surface` | `black`                  | `#f0f0f0`                  | Default deletion tooltip background and arrow                |
+| `--palette-tooltip-text`    | `#fff`                   | `#1a1a1a`                  | Default deletion tooltip icon, text and focus ring           |
 
 > `--palette-focus-ring` is themeable so the focus outline can stay visible in dark mode, but its light and dark defaults are chosen for WCAG-compliant contrast against the palette surface. Override it only with a value that preserves sufficient contrast.
+
+> The tooltip tokens only style the **default** deletion tooltip. Passing a [`tooltipClassName`](#deletion-tooltip-class) replaces the default class and its styling, so a custom tooltip owns its own colors.
 
 ### Dark Mode
 
@@ -639,7 +643,7 @@ Every focusable control in the palette shares the same keyboard focus ring: a `2
 The ring color comes from the [`--palette-focus-ring`](#tokens) token, whose light and dark defaults are tuned for WCAG-compliant contrast against the palette surface:
 
 - **Dark `#1a1a1a`** on the light surface, flipping to **light `#f0f0f0`** in the dark theme. For a slot the ring is drawn in the 2px offset gap over the palette surface, so it stays high-contrast whatever the slot color.
-- The deletion trash button keeps a fixed **light `#fff`** ring because its tooltip is dark in every theme.
+- The deletion trash button rings in [`--palette-tooltip-text`](#tokens) so it contrasts with the tooltip in both themes (light `#fff` on the default dark tooltip, dark `#1a1a1a` on the light dark-theme tooltip).
 
 Under Windows High Contrast (`forced-colors`), the ring switches to the system `Highlight` color.
 

--- a/src/lib/components/Palette.svelte
+++ b/src/lib/components/Palette.svelte
@@ -817,10 +817,12 @@
 	}
 
 	/*
-	 * Token defaults are declared at zero specificity via :where() so any ordinary
+	 * Token defaults, declared at zero specificity via :where() so any ordinary
 	 * consumer rule — an inline style, or a class on the root — overrides them
 	 * without !important and without coupling to internal BEM class names. The
 	 * visual properties below stay on `.palette` and read the tokens through var().
+	 * These are also the universal fallback: a browser without light-dark() support
+	 * keeps them (light only) instead of breaking.
 	 */
 	:where(.palette) {
 		--palette-surface: #fafafa;
@@ -854,53 +856,46 @@
 	}
 
 	/*
-	 * Dark theme token remap, also at zero specificity (:where) so consumer token
-	 * overrides win in dark mode too. Applied automatically when the OS prefers a
-	 * dark scheme (unless the host opts out with data-palette-theme="light"), and
-	 * unconditionally when the host forces it with data-palette-theme="dark". The
-	 * two blocks are intentionally identical and must stay in sync — plain CSS
-	 * cannot share a declaration list between a media-conditional and an
-	 * unconditional selector. The focus ring flips to a light value so it keeps its
-	 * WCAG-compliant contrast against the dark surface.
+	 * Dark theme. Where light-dark() is supported, every theme-varying token is
+	 * declared once as light-dark(<light>, <dark>) and resolved from the
+	 * `color-scheme` on the root: `light dark` follows the OS, and data-palette-theme
+	 * forces one scheme. This replaces the previous pair of identical dark
+	 * declaration lists (a @media block and a forced-attribute block) with a single
+	 * source of truth. Browsers without light-dark() keep the light defaults above
+	 * (no dark mode) rather than breaking. The focus-ring dark value stays
+	 * WCAG-contrasting against the dark surface.
 	 */
-	@media (prefers-color-scheme: dark) {
-		:where(.palette:not([data-palette-theme='light'])) {
-			--palette-surface: #1e1e1e;
-			--palette-text: #ededed;
-			--palette-border: #3a3a3a;
-			--palette-divider: #3a3a3a;
-			--palette-icon: #d0d0d0;
-			--palette-icon-disabled: #6a6a6a;
-			--palette-slot-border: rgba(255, 255, 255, 0.2);
-			--palette-slot-empty: #777777;
-			--palette-slot-ring: #6a6a6a;
-			--palette-input-surface: #2a2a2a;
-			--palette-input-text: rgba(255, 255, 255, 0.75);
-			--palette-error: #ff6b5e;
-			--palette-error-message: #b0b0b0;
-			--palette-focus-ring: #f0f0f0;
-			--palette-tooltip-surface: #f0f0f0;
-			--palette-tooltip-text: #1a1a1a;
+	@supports (color: light-dark(#000, #fff)) {
+		:where(.palette) {
+			--palette-surface: light-dark(#fafafa, #1e1e1e);
+			--palette-text: light-dark(black, #ededed);
+			--palette-border: light-dark(#e5e5e5, #3a3a3a);
+			--palette-divider: light-dark(#e9e9e9, #3a3a3a);
+			--palette-icon: light-dark(#646464, #d0d0d0);
+			--palette-icon-disabled: light-dark(#bdbdbd, #6a6a6a);
+			--palette-slot-border: light-dark(rgba(0, 0, 0, 0.2), rgba(255, 255, 255, 0.2));
+			--palette-slot-empty: light-dark(#aaa, #777777);
+			--palette-slot-ring: light-dark(#9e9e9e, #6a6a6a);
+			--palette-input-surface: light-dark(rgba(255, 255, 255, 1), #2a2a2a);
+			--palette-input-text: light-dark(rgba(0, 0, 0, 0.6), rgba(255, 255, 255, 0.75));
+			--palette-error: light-dark(#c0392b, #ff6b5e);
+			--palette-error-message: light-dark(#595959, #b0b0b0);
+			--palette-focus-ring: light-dark(#1a1a1a, #f0f0f0);
+			--palette-tooltip-surface: light-dark(black, #f0f0f0);
+			--palette-tooltip-text: light-dark(#fff, #1a1a1a);
 		}
-	}
 
-	:where(.palette[data-palette-theme='dark']) {
-		--palette-surface: #1e1e1e;
-		--palette-text: #ededed;
-		--palette-border: #3a3a3a;
-		--palette-divider: #3a3a3a;
-		--palette-icon: #d0d0d0;
-		--palette-icon-disabled: #6a6a6a;
-		--palette-slot-border: rgba(255, 255, 255, 0.2);
-		--palette-slot-empty: #777777;
-		--palette-slot-ring: #6a6a6a;
-		--palette-input-surface: #2a2a2a;
-		--palette-input-text: rgba(255, 255, 255, 0.75);
-		--palette-error: #ff6b5e;
-		--palette-error-message: #b0b0b0;
-		--palette-focus-ring: #f0f0f0;
-		--palette-tooltip-surface: #f0f0f0;
-		--palette-tooltip-text: #1a1a1a;
+		.palette {
+			color-scheme: light dark;
+		}
+
+		.palette[data-palette-theme='light'] {
+			color-scheme: light;
+		}
+
+		.palette[data-palette-theme='dark'] {
+			color-scheme: dark;
+		}
 	}
 
 	/*

--- a/src/lib/components/Palette.svelte
+++ b/src/lib/components/Palette.svelte
@@ -811,7 +811,8 @@
 </template>
 
 <style>
-	:global(*) {
+	.palette,
+	:global(.palette *) {
 		box-sizing: border-box;
 	}
 

--- a/src/lib/components/Palette.svelte
+++ b/src/lib/components/Palette.svelte
@@ -834,6 +834,8 @@
 		--palette-error: #c0392b;
 		--palette-error-message: #595959;
 		--palette-focus-ring: #1a1a1a;
+		--palette-tooltip-surface: black;
+		--palette-tooltip-text: #fff;
 
 		width: 100%;
 		color: var(--palette-text, black);
@@ -868,6 +870,8 @@
 			--palette-error: #ff6b5e;
 			--palette-error-message: #b0b0b0;
 			--palette-focus-ring: #f0f0f0;
+			--palette-tooltip-surface: #f0f0f0;
+			--palette-tooltip-text: #1a1a1a;
 		}
 	}
 
@@ -886,6 +890,36 @@
 		--palette-error: #ff6b5e;
 		--palette-error-message: #b0b0b0;
 		--palette-focus-ring: #f0f0f0;
+		--palette-tooltip-surface: #f0f0f0;
+		--palette-tooltip-text: #1a1a1a;
+	}
+
+	/*
+	 * Theme-aware deletion tooltip. The default svelte-use-tooltip bubble ships a
+	 * fixed black background; because it renders inline inside the palette
+	 * (portal: false), it inherits the palette tokens, so restyle it to track the
+	 * theme instead of staying black on a dark surface. A custom tooltipClassName
+	 * replaces the default class, opting out of these rules (the consumer owns it).
+	 */
+	.palette :global(.__tooltip) {
+		background-color: var(--palette-tooltip-surface, black);
+		color: var(--palette-tooltip-text, #fff);
+	}
+
+	.palette :global(.__tooltip-top::after) {
+		border-top-color: var(--palette-tooltip-surface, black);
+	}
+
+	.palette :global(.__tooltip-bottom::after) {
+		border-bottom-color: var(--palette-tooltip-surface, black);
+	}
+
+	.palette :global(.__tooltip-left::after) {
+		border-left-color: var(--palette-tooltip-surface, black);
+	}
+
+	.palette :global(.__tooltip-right::after) {
+		border-right-color: var(--palette-tooltip-surface, black);
 	}
 
 	.palette__content {

--- a/src/lib/components/Palette.svelte
+++ b/src/lib/components/Palette.svelte
@@ -831,6 +831,7 @@
 		--palette-divider: #e9e9e9;
 		--palette-icon: #646464;
 		--palette-icon-disabled: #bdbdbd;
+		--palette-loader: #ccc;
 		--palette-radius: 0.3rem;
 		--palette-font-family: Helvetica, sans-serif;
 		--palette-slot-size: 1rem;
@@ -873,6 +874,7 @@
 			--palette-divider: light-dark(#e9e9e9, #3a3a3a);
 			--palette-icon: light-dark(#646464, #d0d0d0);
 			--palette-icon-disabled: light-dark(#bdbdbd, #6a6a6a);
+			--palette-loader: light-dark(#ccc, #555555);
 			--palette-slot-border: light-dark(rgba(0, 0, 0, 0.2), rgba(255, 255, 255, 0.2));
 			--palette-slot-empty: light-dark(#aaa, #777777);
 			--palette-slot-ring: light-dark(#9e9e9e, #6a6a6a);

--- a/src/lib/components/Palette.svelte
+++ b/src/lib/components/Palette.svelte
@@ -816,7 +816,13 @@
 		box-sizing: border-box;
 	}
 
-	.palette {
+	/*
+	 * Token defaults are declared at zero specificity via :where() so any ordinary
+	 * consumer rule — an inline style, or a class on the root — overrides them
+	 * without !important and without coupling to internal BEM class names. The
+	 * visual properties below stay on `.palette` and read the tokens through var().
+	 */
+	:where(.palette) {
 		--palette-surface: #fafafa;
 		--palette-text: black;
 		--palette-border: #e5e5e5;
@@ -836,7 +842,9 @@
 		--palette-focus-ring: #1a1a1a;
 		--palette-tooltip-surface: black;
 		--palette-tooltip-text: #fff;
+	}
 
+	.palette {
 		width: 100%;
 		color: var(--palette-text, black);
 		display: flex;
@@ -846,16 +854,17 @@
 	}
 
 	/*
-	 * Dark theme token remap. Applied automatically when the OS prefers a dark
-	 * scheme (unless the host opts out with data-palette-theme="light"), and
-	 * unconditionally when the host forces it with data-palette-theme="dark".
-	 * The two blocks are intentionally identical and must stay in sync — plain
-	 * CSS cannot share a declaration list between a media-conditional and an
-	 * unconditional selector. The focus ring flips to a light value so it keeps
-	 * its WCAG-compliant contrast against the dark surface.
+	 * Dark theme token remap, also at zero specificity (:where) so consumer token
+	 * overrides win in dark mode too. Applied automatically when the OS prefers a
+	 * dark scheme (unless the host opts out with data-palette-theme="light"), and
+	 * unconditionally when the host forces it with data-palette-theme="dark". The
+	 * two blocks are intentionally identical and must stay in sync — plain CSS
+	 * cannot share a declaration list between a media-conditional and an
+	 * unconditional selector. The focus ring flips to a light value so it keeps its
+	 * WCAG-compliant contrast against the dark surface.
 	 */
 	@media (prefers-color-scheme: dark) {
-		.palette:not([data-palette-theme='light']) {
+		:where(.palette:not([data-palette-theme='light'])) {
 			--palette-surface: #1e1e1e;
 			--palette-text: #ededed;
 			--palette-border: #3a3a3a;
@@ -875,7 +884,7 @@
 		}
 	}
 
-	.palette[data-palette-theme='dark'] {
+	:where(.palette[data-palette-theme='dark']) {
 		--palette-surface: #1e1e1e;
 		--palette-text: #ededed;
 		--palette-border: #3a3a3a;

--- a/src/lib/components/Palette.svelte
+++ b/src/lib/components/Palette.svelte
@@ -28,6 +28,8 @@
 
 	import type { Snippet } from 'svelte'
 
+	import type { HTMLAttributes } from 'svelte/elements'
+
 	import type { NormalizedColor, NormalizedColorGroup } from '../utils/utils.js'
 
 	import type {
@@ -124,7 +126,8 @@
 		input = undefined,
 		tools = undefined,
 		settings = undefined,
-	}: Props = $props()
+		...restProps
+	}: Props & Omit<HTMLAttributes<HTMLDivElement>, keyof Props> = $props()
 
 	const _paletteId = $props.id()
 
@@ -590,7 +593,7 @@
 	}
 </script>
 
-<div data-palette-id={_paletteId} class="palette {className}" data-testid="__palette__" data-palette>
+<div {...restProps} data-palette-id={_paletteId} class="palette {className}" data-testid="__palette__" data-palette>
 	<section class="palette__content" class:palette__content--compact={_isCompact} style="--num-columns: {_numColumns}">
 		{#if !_isCompact}
 			{@render header?.({ selectedColor })}
@@ -813,12 +816,30 @@
 	}
 
 	.palette {
+		--palette-surface: #fafafa;
+		--palette-text: black;
+		--palette-border: #e5e5e5;
+		--palette-divider: #e9e9e9;
+		--palette-icon: #646464;
+		--palette-icon-disabled: #bdbdbd;
+		--palette-radius: 0.3rem;
+		--palette-font-family: Helvetica, sans-serif;
+		--palette-slot-size: 1rem;
+		--palette-slot-border: rgba(0, 0, 0, 0.2);
+		--palette-slot-empty: #aaa;
+		--palette-slot-ring: #9e9e9e;
+		--palette-input-surface: rgba(255, 255, 255, 1);
+		--palette-input-text: rgba(0, 0, 0, 0.6);
+		--palette-error: #c0392b;
+		--palette-error-message: #595959;
+		--palette-focus-ring: #1a1a1a;
+
 		width: 100%;
-		color: black;
+		color: var(--palette-text, black);
 		display: flex;
 		flex-direction: column;
 		align-items: center;
-		background-color: #fafafa;
+		background-color: var(--palette-surface, #fafafa);
 	}
 
 	.palette__content {

--- a/src/lib/components/Palette.svelte
+++ b/src/lib/components/Palette.svelte
@@ -842,6 +842,51 @@
 		background-color: var(--palette-surface, #fafafa);
 	}
 
+	/*
+	 * Dark theme token remap. Applied automatically when the OS prefers a dark
+	 * scheme (unless the host opts out with data-palette-theme="light"), and
+	 * unconditionally when the host forces it with data-palette-theme="dark".
+	 * The two blocks are intentionally identical and must stay in sync — plain
+	 * CSS cannot share a declaration list between a media-conditional and an
+	 * unconditional selector. The focus ring flips to a light value so it keeps
+	 * its WCAG-compliant contrast against the dark surface.
+	 */
+	@media (prefers-color-scheme: dark) {
+		.palette:not([data-palette-theme='light']) {
+			--palette-surface: #1e1e1e;
+			--palette-text: #ededed;
+			--palette-border: #3a3a3a;
+			--palette-divider: #3a3a3a;
+			--palette-icon: #d0d0d0;
+			--palette-icon-disabled: #6a6a6a;
+			--palette-slot-border: rgba(255, 255, 255, 0.2);
+			--palette-slot-empty: #777777;
+			--palette-slot-ring: #6a6a6a;
+			--palette-input-surface: #2a2a2a;
+			--palette-input-text: rgba(255, 255, 255, 0.75);
+			--palette-error: #ff6b5e;
+			--palette-error-message: #b0b0b0;
+			--palette-focus-ring: #f0f0f0;
+		}
+	}
+
+	.palette[data-palette-theme='dark'] {
+		--palette-surface: #1e1e1e;
+		--palette-text: #ededed;
+		--palette-border: #3a3a3a;
+		--palette-divider: #3a3a3a;
+		--palette-icon: #d0d0d0;
+		--palette-icon-disabled: #6a6a6a;
+		--palette-slot-border: rgba(255, 255, 255, 0.2);
+		--palette-slot-empty: #777777;
+		--palette-slot-ring: #6a6a6a;
+		--palette-input-surface: #2a2a2a;
+		--palette-input-text: rgba(255, 255, 255, 0.75);
+		--palette-error: #ff6b5e;
+		--palette-error-message: #b0b0b0;
+		--palette-focus-ring: #f0f0f0;
+	}
+
 	.palette__content {
 		width: 100%;
 		min-height: 70px;

--- a/src/lib/components/PaletteError.svelte
+++ b/src/lib/components/PaletteError.svelte
@@ -60,7 +60,7 @@
 		align-items: center;
 		gap: 0.4rem;
 		text-align: center;
-		color: #c0392b;
+		color: var(--palette-error, #c0392b);
 		font-family: inherit;
 	}
 
@@ -71,7 +71,7 @@
 
 	.palette__error__message {
 		font-size: 0.75rem;
-		color: #595959;
+		color: var(--palette-error-message, #595959);
 		word-break: break-word;
 	}
 </style>

--- a/src/lib/components/PaletteIconButton.svelte
+++ b/src/lib/components/PaletteIconButton.svelte
@@ -62,11 +62,11 @@
 		height: 2rem;
 		margin: 0;
 		padding: 0;
-		background-color: #fafafa;
+		background-color: var(--palette-surface, #fafafa);
 		border-width: 1px;
-		border-color: #e5e5e5;
+		border-color: var(--palette-border, #e5e5e5);
 		border-style: solid;
-		border-radius: 0.3rem;
+		border-radius: var(--palette-radius, 0.3rem);
 		cursor: pointer;
 	}
 
@@ -75,12 +75,12 @@
 	}
 
 	.icon_button__button:focus-visible {
-		outline: 2px solid #1a1a1a;
+		outline: 2px solid var(--palette-focus-ring, #1a1a1a);
 		outline-offset: 2px;
 	}
 
 	.icon_button__button--active {
-		background-color: #e5e5e5;
+		background-color: var(--palette-border, #e5e5e5);
 	}
 
 	@media (forced-colors: active) {
@@ -103,7 +103,7 @@
 		.icon_button__button > svg line,
 		.icon_button__button > svg polyline
 	) {
-		stroke: #646464;
+		stroke: var(--palette-icon, #646464);
 	}
 
 	:global(
@@ -112,6 +112,6 @@
 		.icon_button__button:disabled > svg line,
 		.icon_button__button:disabled > svg polyline
 	) {
-		stroke: #bdbdbd;
+		stroke: var(--palette-icon-disabled, #bdbdbd);
 	}
 </style>

--- a/src/lib/components/PaletteInput.svelte
+++ b/src/lib/components/PaletteInput.svelte
@@ -156,19 +156,19 @@
 	}
 
 	.palette_input__input {
-		font-family: Helvetica, sans-serif;
+		font-family: var(--palette-font-family, Helvetica, sans-serif);
 		font-size: 0.8rem;
 		width: 71%;
 		height: 2rem;
 		margin: 0;
 		padding: 0.4rem;
 		outline: none;
-		color: rgba(0, 0, 0, 0.6);
-		background: rgba(255, 255, 255, 1);
+		color: var(--palette-input-text, rgba(0, 0, 0, 0.6));
+		background: var(--palette-input-surface, rgba(255, 255, 255, 1));
 		border-width: 1px;
-		border-color: #e5e5e5;
+		border-color: var(--palette-border, #e5e5e5);
 		border-style: solid;
-		border-radius: 0.3rem;
+		border-radius: var(--palette-radius, 0.3rem);
 		border-right-width: 0;
 		border-top-right-radius: 0;
 		border-bottom-right-radius: 0;
@@ -179,7 +179,7 @@
 	}
 
 	.palette_input__input:focus-visible {
-		outline: 2px solid #1a1a1a;
+		outline: 2px solid var(--palette-focus-ring, #1a1a1a);
 		outline-offset: 2px;
 		/* Lift above the adjoining submit button (which is position: relative) so the
 		   ring shows on all four sides instead of being covered at the shared edge. */
@@ -206,7 +206,7 @@
 
 	.palette__divider {
 		border: none;
-		background-color: #e9e9e9;
+		background-color: var(--palette-divider, #e9e9e9);
 		width: 100%;
 		height: 1px;
 		margin: 0;

--- a/src/lib/components/PaletteLoader.svelte
+++ b/src/lib/components/PaletteLoader.svelte
@@ -17,7 +17,7 @@
 		aria-hidden="true"
 		xmlns="http://www.w3.org/2000/svg"
 	>
-		<path d="M12,2.5 A9.5,9.5 0 0,1 21.5,12" stroke-width="2" stroke="#ccc" fill="none" />
+		<path d="M12,2.5 A9.5,9.5 0 0,1 21.5,12" stroke-width="2" fill="none" />
 	</svg>
 	<span class="palette__loader__label">{label}</span>
 </div>
@@ -26,6 +26,10 @@
 	.palette__loader__spinner {
 		transform-origin: 50% 50%;
 		animation: palette-spin 1s linear infinite;
+	}
+
+	.palette__loader__spinner path {
+		stroke: var(--palette-loader, #ccc);
 	}
 
 	.palette__loader__label {

--- a/src/lib/components/PaletteSlot.svelte
+++ b/src/lib/components/PaletteSlot.svelte
@@ -56,11 +56,11 @@
 
 <style>
 	button {
-		width: 1rem;
-		height: 1rem;
+		width: var(--palette-slot-size, 1rem);
+		height: var(--palette-slot-size, 1rem);
 		margin: 1px 0 0 0;
 		padding: 0;
-		border: 1px solid rgba(0, 0, 0, 0.2);
+		border: 1px solid var(--palette-slot-border, rgba(0, 0, 0, 0.2));
 		border-radius: 50%;
 		background-color: var(--color);
 	}
@@ -70,7 +70,7 @@
 	}
 
 	button:focus-visible {
-		outline: 2px solid #1a1a1a;
+		outline: 2px solid var(--palette-focus-ring, #1a1a1a);
 		outline-offset: 2px;
 	}
 
@@ -81,11 +81,11 @@
 	}
 
 	button.selected {
-		/* Selection ring drawn as a box-shadow; the #fafafa layer keeps a 2px gap
-		   between the swatch and the grey ring. */
+		/* Selection ring drawn as a box-shadow; the surface layer keeps a 2px gap
+		   between the slot and the grey ring. */
 		box-shadow:
-			0 0 0 2px #fafafa,
-			0 0 0 4px #9e9e9e;
+			0 0 0 2px var(--palette-surface, #fafafa),
+			0 0 0 4px var(--palette-slot-ring, #9e9e9e);
 	}
 
 	button.clickable {
@@ -93,7 +93,12 @@
 	}
 
 	button.empty {
-		border: #aaa solid 1px;
-		background: linear-gradient(to top left, #00000000 calc(50% - 1px), #aaa 50% 50%, #00000000 calc(50% + 1px));
+		border: var(--palette-slot-empty, #aaa) solid 1px;
+		background: linear-gradient(
+			to top left,
+			#00000000 calc(50% - 1px),
+			var(--palette-slot-empty, #aaa) 50% 50%,
+			#00000000 calc(50% + 1px)
+		);
 	}
 </style>

--- a/src/lib/components/PaletteTools.svelte
+++ b/src/lib/components/PaletteTools.svelte
@@ -69,7 +69,7 @@
 
 	.palette__divider {
 		border: none;
-		background-color: #e9e9e9;
+		background-color: var(--palette-divider, #e9e9e9);
 		width: 100%;
 		height: 1px;
 		margin: 0;

--- a/src/lib/components/PaletteTrashButton.svelte
+++ b/src/lib/components/PaletteTrashButton.svelte
@@ -54,7 +54,7 @@
 	}
 
 	.trash_button__button:focus-visible {
-		outline: 2px solid #fff;
+		outline: 2px solid var(--palette-tooltip-text, #fff);
 		outline-offset: 2px;
 	}
 
@@ -83,6 +83,6 @@
 		.trash_button__button > svg line,
 		.trash_button__button > svg polyline
 	) {
-		stroke: #fff;
+		stroke: var(--palette-tooltip-text, #fff);
 	}
 </style>

--- a/src/lib/components/PaletteTrashButton.svelte
+++ b/src/lib/components/PaletteTrashButton.svelte
@@ -59,7 +59,7 @@
 	}
 
 	.trash_button__button--active {
-		background-color: #e5e5e5;
+		background-color: var(--palette-border, #e5e5e5);
 		outline: none;
 	}
 

--- a/src/lib/components/__tests__/Palette.test.ts
+++ b/src/lib/components/__tests__/Palette.test.ts
@@ -827,6 +827,22 @@ test('Does not expose a main landmark on the root', async () => {
 	expect(root).toHaveAttribute('data-palette')
 })
 
+test('Forwards style and extra attributes to the root element', async () => {
+	const colors = ['#ff0', '#0ff', '#f0f']
+	setup(Palette, {
+		props: { colors, style: '--palette-surface: #123456;', 'data-palette-theme': 'dark' },
+	})
+
+	await screen.findAllByTestId('__palette-slot__')
+
+	const root = screen.getByTestId('__palette__')
+	expect(root.style.getPropertyValue('--palette-surface')).toBe('#123456')
+	expect(root).toHaveAttribute('data-palette-theme', 'dark')
+	// The component's own identity attributes are preserved alongside forwarded ones.
+	expect(root).toHaveAttribute('data-palette')
+	expect(root).toHaveClass('palette')
+})
+
 test('Exposes the slot grid as a listbox', async () => {
 	const colors = ['#ff0', '#0ff', '#f0f']
 	setup(Palette, { colors })

--- a/src/lib/components/__tests__/Palette.test.ts
+++ b/src/lib/components/__tests__/Palette.test.ts
@@ -838,7 +838,6 @@ test('Forwards style and extra attributes to the root element', async () => {
 	const root = screen.getByTestId('__palette__')
 	expect(root.style.getPropertyValue('--palette-surface')).toBe('#123456')
 	expect(root).toHaveAttribute('data-palette-theme', 'dark')
-	// The component's own identity attributes are preserved alongside forwarded ones.
 	expect(root).toHaveAttribute('data-palette')
 	expect(root).toHaveClass('palette')
 })

--- a/src/lib/components/__tests__/Palette.tokens.test.ts
+++ b/src/lib/components/__tests__/Palette.tokens.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import { compile } from 'svelte/compiler'
+
+// jsdom in this suite does not inject the component's compiled CSS, so the
+// token-override cascade cannot be asserted at runtime. Instead we lock in the
+// contract that makes it work: the --palette-* defaults are declared at zero
+// specificity (:where(...)), so an ordinary consumer rule on the root — an inline
+// style, or a class — always overrides them. If this regresses to a bare
+// `.palette` selector, Svelte's scoping raises it to (0,2,0) and consumer theming
+// silently stops working.
+test('Declares the palette token defaults at zero specificity via :where()', () => {
+	const source = readFileSync(resolve(process.cwd(), 'src/lib/components/Palette.svelte'), 'utf8')
+	const { css } = compile(source, { name: 'Palette', filename: 'Palette.svelte', css: 'external' })
+
+	const code = (css?.code ?? '').replace(/\/\*[\s\S]*?\*\//g, '').replace(/\s+/g, ' ')
+
+	// Capture the selector of the rule that declares a --palette-* default.
+	const tokenRule = /([^{}]*)\{[^{}]*--palette-surface\s*:/.exec(code)
+
+	expect(tokenRule?.[1]).toBeTruthy()
+	expect(tokenRule?.[1]).toContain(':where(')
+})

--- a/src/lib/components/__tests__/Palette.tokens.test.ts
+++ b/src/lib/components/__tests__/Palette.tokens.test.ts
@@ -3,20 +3,12 @@ import { resolve } from 'node:path'
 
 import { compile } from 'svelte/compiler'
 
-// jsdom in this suite does not inject the component's compiled CSS, so the
-// token-override cascade cannot be asserted at runtime. Instead we lock in the
-// contract that makes it work: the --palette-* defaults are declared at zero
-// specificity (:where(...)), so an ordinary consumer rule on the root — an inline
-// style, or a class — always overrides them. If this regresses to a bare
-// `.palette` selector, Svelte's scoping raises it to (0,2,0) and consumer theming
-// silently stops working.
 test('Declares the palette token defaults at zero specificity via :where()', () => {
 	const source = readFileSync(resolve(process.cwd(), 'src/lib/components/Palette.svelte'), 'utf8')
 	const { css } = compile(source, { name: 'Palette', filename: 'Palette.svelte', css: 'external' })
 
 	const code = (css?.code ?? '').replace(/\/\*[\s\S]*?\*\//g, '').replace(/\s+/g, ' ')
 
-	// Capture the selector of the rule that declares a --palette-* default.
 	const tokenRule = /([^{}]*)\{[^{}]*--palette-surface\s*:/.exec(code)
 
 	expect(tokenRule?.[1]).toBeTruthy()

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -27,6 +27,7 @@
 		<HeaderNavItem href="/example5" text="Example 5" />
 		<HeaderNavItem href="/example6" text="Example 6" />
 		<HeaderNavItem href="/example7" text="Example 7" />
+		<HeaderNavItem href="/example8" text="Example 8" />
 	</HeaderNav>
 </Header>
 
@@ -39,6 +40,7 @@
 		<SideNavLink href="/example5" text="Example 5" />
 		<SideNavLink href="/example6" text="Example 6" />
 		<SideNavLink href="/example7" text="Example 7" />
+		<SideNavLink href="/example8" text="Example 8" />
 	</SideNavItems>
 </SideNav>
 

--- a/src/routes/example1/+page.svelte
+++ b/src/routes/example1/+page.svelte
@@ -108,6 +108,7 @@
 			{#key unique}
 				<Palette
 					class="palette__custom"
+					data-palette-theme="light"
 					labels={{ slots: 'Background color slots' }}
 					bind:colors
 					compactColorIndices={showCompactControl ? compactIndices : null}

--- a/src/routes/example2/+page.svelte
+++ b/src/routes/example2/+page.svelte
@@ -12,7 +12,7 @@
 <main class="example2" style="--bgColor:{bgColor}">
 	<div class="content">
 		<div class="content__grid">
-			<Palette class="palette__custom" colors={colors1} numColumns="5" presentational>
+			<Palette class="palette__custom" colors={colors1} numColumns="5" presentational data-palette-theme="light">
 				{#snippet slot({ color })}
 					<div style="--color: {color}" class="slot"></div>
 				{/snippet}
@@ -25,7 +25,7 @@
 					</div>
 				{/snippet}
 			</Palette>
-			<Palette class="palette__custom" colors={colors2} numColumns="5" presentational>
+			<Palette class="palette__custom" colors={colors2} numColumns="5" presentational data-palette-theme="light">
 				{#snippet slot({ color })}
 					<div style="--color: {color}" class="slot"></div>
 				{/snippet}
@@ -38,7 +38,7 @@
 					</div>
 				{/snippet}
 			</Palette>
-			<Palette class="palette__custom" colors={colors3} numColumns="5" presentational>
+			<Palette class="palette__custom" colors={colors3} numColumns="5" presentational data-palette-theme="light">
 				{#snippet slot({ color })}
 					<div style="--color: {color}" class="slot"></div>
 				{/snippet}
@@ -51,7 +51,7 @@
 					</div>
 				{/snippet}
 			</Palette>
-			<Palette class="palette__custom" colors={colors4} numColumns="5" presentational>
+			<Palette class="palette__custom" colors={colors4} numColumns="5" presentational data-palette-theme="light">
 				{#snippet slot({ color })}
 					<div style="--color: {color}" class="slot"></div>
 				{/snippet}

--- a/src/routes/example3/+page.svelte
+++ b/src/routes/example3/+page.svelte
@@ -41,7 +41,7 @@
 
 <main class="example3" style="--bgColor:#000">
 	<div class="content">
-		<Palette class="palette__custom" colors={blueColors} numColumns="10" presentational>
+		<Palette class="palette__custom" colors={blueColors} numColumns="10" presentational data-palette-theme="light">
 			{#snippet header()}
 				<div class="header">
 					<h1>Blue</h1>
@@ -59,7 +59,13 @@
 			{#snippet input()}{/snippet}
 			{#snippet tools()}{/snippet}
 		</Palette>
-		<Palette class="palette__custom" colors={purpleColors} numColumns="10" presentational>
+		<Palette
+			class="palette__custom"
+			colors={purpleColors}
+			numColumns="10"
+			presentational
+			data-palette-theme="light"
+		>
 			{#snippet header()}
 				<div class="header">
 					<h1>Purple</h1>
@@ -77,7 +83,7 @@
 			{#snippet input()}{/snippet}
 			{#snippet tools()}{/snippet}
 		</Palette>
-		<Palette class="palette__custom" colors={redColors} numColumns="10" presentational>
+		<Palette class="palette__custom" colors={redColors} numColumns="10" presentational data-palette-theme="light">
 			{#snippet header()}
 				<div class="header">
 					<h1>Red</h1>

--- a/src/routes/example4/+page.svelte
+++ b/src/routes/example4/+page.svelte
@@ -30,7 +30,15 @@
 <main class="example4" style="--bgColor:#000">
 	<div class="content">
 		<div>
-			<Palette {colors} {selectedColor} numColumns={5} {showInput} allowDuplicates onselect={_onSelect}>
+			<Palette
+				{colors}
+				{selectedColor}
+				numColumns={5}
+				{showInput}
+				allowDuplicates
+				data-palette-theme="light"
+				onselect={_onSelect}
+			>
 				{#snippet header({ selectedColor })}
 					<div class="header" style="--color:{selectedColor}; --textColor: {textColor}">
 						{selectedColor ?? ''}

--- a/src/routes/example5/+page.svelte
+++ b/src/routes/example5/+page.svelte
@@ -28,6 +28,7 @@
 	<div class="content">
 		<Palette
 			class="palette__custom"
+			data-palette-theme="light"
 			{colors}
 			bind:selectedColor
 			numColumns={6}

--- a/src/routes/example6/+page.svelte
+++ b/src/routes/example6/+page.svelte
@@ -49,6 +49,7 @@
 	<div class="content">
 		<Palette
 			class="palette__custom"
+			data-palette-theme="light"
 			{colors}
 			bind:selectedColor
 			numColumns={4}
@@ -78,7 +79,12 @@
 		Omitting the <code>error</code> snippet renders the bundled <code>PaletteError</code> component instead:
 	</p>
 	<div class="content">
-		<Palette class="palette__custom palette__custom--default" colors={_failingSource} numColumns={4} />
+		<Palette
+			class="palette__custom palette__custom--default"
+			colors={_failingSource}
+			numColumns={4}
+			data-palette-theme="light"
+		/>
 	</div>
 </main>
 

--- a/src/routes/example7/+page.svelte
+++ b/src/routes/example7/+page.svelte
@@ -56,6 +56,7 @@
 	<div class="content">
 		<Palette
 			class="palette__custom"
+			data-palette-theme="light"
 			bind:colors
 			bind:selectedColor
 			numColumns={4}
@@ -155,7 +156,6 @@
 
 	.example7 :global(.palette[data-palette].palette__custom) {
 		border-radius: 0.5rem;
-		overflow: hidden;
 	}
 
 	.settings {

--- a/src/routes/example8/+page.svelte
+++ b/src/routes/example8/+page.svelte
@@ -168,7 +168,12 @@
 		width: 100%;
 		max-width: 22rem;
 		border-radius: 0.75rem;
-		overflow: hidden;
 		box-shadow: 0 10px 30px rgba(0, 0, 0, 0.25);
+	}
+
+	/* Round the palette itself instead of clipping the stage: an overflow:hidden
+	   ancestor would hide the inline (portal:false) deletion tooltip. */
+	.stage :global(.palette[data-palette]) {
+		border-radius: inherit;
 	}
 </style>

--- a/src/routes/example8/+page.svelte
+++ b/src/routes/example8/+page.svelte
@@ -1,0 +1,174 @@
+<script lang="ts">
+	import { Palette } from '$lib'
+
+	import type { ColorsProp, ColorValue } from '$lib/types'
+
+	let colors = $state<ColorsProp | null>([
+		'#865C54',
+		'#8F5447',
+		'#A65846',
+		'#A9715E',
+		'#AD8C72',
+		'#C2B091',
+		'#172B41',
+		'#32465C',
+		'#617899',
+		'#9BA2BC',
+	])
+	let selectedColor = $state<ColorValue | null>('#865C54')
+
+	// data-palette-theme drives the built-in dark mode:
+	// - "auto" (or absent) follows the OS via prefers-color-scheme
+	// - "light" forces the light tokens
+	// - "dark" forces the dark tokens regardless of the OS preference
+	let theme = $state<'auto' | 'light' | 'dark'>('auto')
+
+	type TokenOverrides = Record<string, string>
+
+	const presets: { name: string; tokens: TokenOverrides }[] = [
+		{ name: 'Defaults', tokens: {} },
+		{
+			name: 'Ocean',
+			tokens: {
+				'--palette-surface': '#0b1f2a',
+				'--palette-text': '#e6f1f5',
+				'--palette-border': '#1c3a48',
+				'--palette-divider': '#1c3a48',
+				'--palette-icon': '#9fd3e0',
+				'--palette-input-surface': '#12303d',
+				'--palette-input-text': '#cfe8ef',
+				'--palette-focus-ring': '#7fd7ff',
+			},
+		},
+		{
+			name: 'Sand',
+			tokens: {
+				'--palette-surface': '#f6efe3',
+				'--palette-text': '#4a3b2a',
+				'--palette-border': '#e0d2ba',
+				'--palette-divider': '#e6dac6',
+				'--palette-icon': '#8a7350',
+				'--palette-radius': '0.75rem',
+				'--palette-input-surface': '#fffaf0',
+			},
+		},
+	]
+
+	let selectedPreset = $state(0)
+
+	const _tokensToStyle = (tokens: TokenOverrides): string =>
+		Object.entries(tokens)
+			.map(([name, value]) => `${name}: ${value}`)
+			.join('; ')
+
+	let paletteStyle = $derived(_tokensToStyle(presets[selectedPreset].tokens))
+</script>
+
+<main class="example8">
+	<section class="controls" aria-label="Theming controls">
+		<fieldset>
+			<legend>Theme mode <code>data-palette-theme</code></legend>
+			<label><input type="radio" name="theme" value="auto" bind:group={theme} /> auto (follows OS)</label>
+			<label><input type="radio" name="theme" value="light" bind:group={theme} /> light</label>
+			<label><input type="radio" name="theme" value="dark" bind:group={theme} /> dark</label>
+		</fieldset>
+
+		<fieldset>
+			<legend>Token preset <code>style="--palette-*"</code></legend>
+			{#each presets as preset, index}
+				<label
+					><input type="radio" name="preset" value={index} bind:group={selectedPreset} /> {preset.name}</label
+				>
+			{/each}
+		</fieldset>
+
+		{#if paletteStyle}
+			<pre class="snippet">&lt;Palette style="{paletteStyle}" /&gt;</pre>
+		{:else}
+			<pre class="snippet">&lt;Palette /&gt;  &lt;!-- default tokens --&gt;</pre>
+		{/if}
+	</section>
+
+	<section class="stage">
+		<Palette
+			bind:colors
+			bind:selectedColor
+			data-palette-theme={theme}
+			style={paletteStyle}
+			showInput
+			deletionMode="tooltip"
+		/>
+	</section>
+</main>
+
+<style>
+	.example8 {
+		min-height: 100%;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 2rem;
+		padding: 2rem 1rem;
+		background-color: #8a8f98;
+		font-family: Helvetica, sans-serif;
+	}
+
+	.controls {
+		width: 100%;
+		max-width: 40rem;
+		display: flex;
+		flex-wrap: wrap;
+		gap: 1rem;
+		align-items: flex-start;
+	}
+
+	.controls fieldset {
+		flex: 1 1 14rem;
+		display: flex;
+		flex-direction: column;
+		gap: 0.4rem;
+		margin: 0;
+		padding: 0.75rem 1rem;
+		border: 1px solid rgba(255, 255, 255, 0.4);
+		border-radius: 0.5rem;
+		background-color: rgba(255, 255, 255, 0.12);
+		color: #fff;
+		font-size: 0.85rem;
+	}
+
+	.controls legend {
+		font-weight: 600;
+	}
+
+	.controls label {
+		display: flex;
+		align-items: center;
+		gap: 0.4rem;
+		cursor: pointer;
+	}
+
+	.controls code {
+		font-family: monospace;
+		font-size: 0.75rem;
+		opacity: 0.85;
+	}
+
+	.snippet {
+		flex-basis: 100%;
+		margin: 0;
+		padding: 0.6rem 0.8rem;
+		overflow-x: auto;
+		border-radius: 0.5rem;
+		background-color: rgba(0, 0, 0, 0.55);
+		color: #f5f5f5;
+		font-size: 0.75rem;
+	}
+
+	.stage {
+		width: 100%;
+		max-width: 22rem;
+		border-radius: 0.75rem;
+		overflow: hidden;
+		box-shadow: 0 10px 30px rgba(0, 0, 0, 0.25);
+	}
+</style>


### PR DESCRIPTION
## Summary

Turns the palette's hardcoded style literals into a `--palette-*` CSS custom property token layer, adds an automatic dark theme, and stops the component from mutating the host document's box model. Consumers can now theme through ordinary inherited custom properties — no `:global()`, no `!important`, and no coupling to internal BEM class names.

Closes #208.

## Changes

- **Token layer.** Declared a `--palette-*` token set on the `.palette` root and consumed it everywhere the color, radius, font and slot-size literals lived, each as `var(--palette-*, <current literal>)`. The literal fallback keeps untouched consumers — and the exported sub-components used standalone — rendering byte-identically.
- **`style` / `...restProps` forwarding.** The root `<div>` now forwards `style` and arbitrary attributes (e.g. `data-palette-theme`), so a single inline `style="--palette-surface: …"` themes the whole subtree.
- **Automatic dark mode.** Under `prefers-color-scheme: dark` the tokens remap to a dark set. Hosts stay in control via `data-palette-theme`: `light` forces light, `dark` forces dark, absent/`auto` follows the OS. The focus ring flips to a light value in the dark theme to keep its WCAG-compliant contrast against the dark surface.
- **Scoped the box-sizing reset.** Replaced the unscoped `:global(*)` reset with `.palette, :global(.palette *)` so the host document's box model is left untouched.
- **Demo.** Added `example8`, an interactive theming + dark-mode showcase (mode switch + token presets), wired into the header and side navigation.
- **Docs.** Rewrote the README `Styles` section: a token table + theming guide as the primary path, a dark-mode section, and the `:global()` route demoted to an advanced escape hatch.

## ⚠️ Breaking changes

- **`box-sizing`**: `Palette` no longer sets `box-sizing: border-box` on the whole host document (`:global(*)`); the reset is now scoped to the palette subtree. Apps that were silently inheriting that reset from this library will revert to `content-box` on their own elements, which can shift layout.
  - **Migration**: add your own reset if you relied on it:
    ```css
    *, *::before, *::after { box-sizing: border-box; }
    ```
- **Dark mode** changes default rendering under a dark OS for consumers who set no tokens. Bound by the `data-palette-theme="light"` opt-out.

Everything else is additive: tokens land as `var(--palette-*, <current literal>)`, and the existing `:global()` overrides against BEM class names keep working unchanged.

## Test plan

- [x] `yarn run check` — svelte-check, 0 errors
- [x] `yarn test:ci` — full vitest suite green (incl. a new test asserting the root forwards `style` and `data-palette-theme`)
- [x] `yarn build` — `svelte-package` + `publint` clean
- [x] `yarn lint` — prettier clean
- [x] Verified in the browser via `example8`: auto dark under a dark OS, `data-palette-theme="light"` opt-out forces light, `data-palette-theme="dark"` force, and inline `style="--palette-*"` presets theme the whole subtree; confirmed the dark focus-ring token resolves to `#f0f0f0`.
