### PR TITLE
feat: Surface color names on default slots

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,11 @@ colors = [
 ]
 ```
 
+Each object accepts:
+
+- `value` — the color (any CSS color string, typically a hex value)
+- `name` (optional) — a human-readable label. By default it becomes the slot's native tooltip (`title`) and accessible name (`aria-label`), so screen readers announce the name instead of the raw value. Colors passed as bare strings, or objects without a `name`, keep announcing their value. Override it per slot through the [`slot` snippet](#snippets).
+
 ## Array of Color Groups
 
 Colors can be organized into named groups by passing an array of `ColorGroup` objects:

--- a/src/lib/components/Palette.svelte
+++ b/src/lib/components/Palette.svelte
@@ -656,6 +656,7 @@
 									{:else}
 										<PaletteSlot
 											color={color.value}
+											name={color.name}
 											role={_optionRole}
 											selected={optionIndex === _selectedIndex}
 											tabindex={_rovingTabindex(optionIndex)}
@@ -733,6 +734,7 @@
 							{:else}
 								<PaletteSlot
 									color={color.value}
+									name={color.name}
 									role={_optionRole}
 									selected={optionIndex === _selectedIndex}
 									tabindex={_rovingTabindex(optionIndex)}

--- a/src/lib/components/PaletteSlot.svelte
+++ b/src/lib/components/PaletteSlot.svelte
@@ -7,6 +7,8 @@
 	interface Props {
 		/** The color value of the slot. */
 		color?: ColorValue | null
+		/** Human-readable name used as the accessible label and native tooltip; falls back to the color value. */
+		name?: string | null
 		/** Whether the slot is selected. */
 		selected?: boolean
 		/** Whether the slot is disabled. */
@@ -21,6 +23,7 @@
 
 	let {
 		color = null,
+		name = null,
 		selected = false,
 		disabled = false,
 		tabindex = 0,
@@ -40,7 +43,8 @@
 
 <button
 	data-testid="__palette-slot__"
-	aria-label={color}
+	aria-label={name ?? color}
+	title={name ?? undefined}
 	{role}
 	aria-selected={role === 'option' ? selected : undefined}
 	{...restProps}

--- a/src/lib/components/__tests__/Palette.test.ts
+++ b/src/lib/components/__tests__/Palette.test.ts
@@ -41,6 +41,17 @@ test('Marks the slot matching selectedColor as selected', async () => {
 	expect(slots[2]).not.toHaveClass('selected')
 })
 
+test('Surfaces a named color on the default slot label and title', async () => {
+	const colors = [{ name: 'Sunbeam', value: '#ff0' }, { value: '#0ff' }]
+	setup(Palette, { props: { colors } })
+
+	const named = await screen.findByLabelText('Sunbeam')
+	expect(named).toHaveAttribute('title', 'Sunbeam')
+
+	const bare = screen.getByLabelText('#0ff')
+	expect(bare).not.toHaveAttribute('title')
+})
+
 test('Displays as many color slots as set in async mode', async () => {
 	let cells = null
 	const colors = Promise.resolve(['#ff0', '#0ff', '#f0f'])
@@ -561,6 +572,14 @@ test('Displays groups with their names and color slots', async () => {
 
 	const cells = await screen.findAllByTestId('__palette-cell__')
 	expect(cells).toHaveLength(5)
+})
+
+test('Surfaces a named color on the default slot inside a group', async () => {
+	const colors = [{ name: 'Warm', colors: [{ name: 'Sunbeam', value: '#ff0' }, '#f80'] }]
+	setup(Palette, { props: { colors } })
+
+	const named = await screen.findByLabelText('Sunbeam')
+	expect(named).toHaveAttribute('title', 'Sunbeam')
 })
 
 test('Does not display group name when group has no name', async () => {

--- a/src/lib/components/__tests__/PaletteSlot.test.ts
+++ b/src/lib/components/__tests__/PaletteSlot.test.ts
@@ -23,6 +23,30 @@ test('Sets empty aria-label if color is not set', () => {
 	expect(slot).toBeInTheDocument()
 })
 
+test('Prefers name over color as aria-label when name is set', () => {
+	setup(PaletteSlot, { color: '#ff0', name: 'Sunbeam' })
+	const slot = screen.getByTestId('__palette-slot__')
+	expect(slot).toHaveAttribute('aria-label', 'Sunbeam')
+})
+
+test('Sets name as the title when name is set', () => {
+	setup(PaletteSlot, { color: '#ff0', name: 'Sunbeam' })
+	const slot = screen.getByTitle('Sunbeam')
+	expect(slot).toBeInTheDocument()
+})
+
+test('Does not set a title when name is not set', () => {
+	setup(PaletteSlot, { color: '#ff0' })
+	const slot = screen.getByTestId('__palette-slot__')
+	expect(slot).not.toHaveAttribute('title')
+})
+
+test('Lets an explicit aria-label override the name', () => {
+	setup(PaletteSlot, { color: '#ff0', name: 'Sunbeam', ['aria-label']: 'Override' })
+	const slot = screen.getByLabelText('Override')
+	expect(slot).toBeInTheDocument()
+})
+
 test('Triggers click event', async () => {
 	const color = '#ff0'
 	const onClick = vi.fn(() => 0)


### PR DESCRIPTION
## Summary

The `name` parsed from `{ name, value }` colors was already carried to the render site but dropped in the default (non-snippet) slot branches, so named colors had no observable effect unless the consumer reimplemented the whole `slot` snippet — and the default slot announced a raw hex string.

This threads the name into the default `PaletteSlot`: it now derives the accessible label and a native tooltip from the name, falling back to the color value when no name is given.

## Changes

- **`PaletteSlot.svelte`** — new optional `name` prop; `aria-label={name ?? color}` and `title={name ?? undefined}`, both placed before `{...restProps}` so an explicit caller `aria-label`/`title` still wins.
- **`Palette.svelte`** — pass `name={color.name}` to the default `PaletteSlot` in both branches (flat list and groups). The transparent slot is untouched.
- **Tests** — `PaletteSlot` covers name→`aria-label` precedence, the `title`, no `title` without a name, and an explicit `aria-label` overriding the name; `Palette` asserts a named color reaches the default slot's label and `title` in both flat and grouped mode.
- **README** — the "Array of Color Objects" section documents that `name` is the default slot's tooltip and accessible label, overridable via the `slot` snippet.

## Behavior change (non-breaking)

`name` is a new optional prop — every existing call site omits it, so the public API is unchanged. For colors declared as `{ name, value }`, the default slot's `aria-label` now becomes the name instead of the hex value and the slot gains a `title`. Colors passed as bare strings, or objects without a `name`, are unaffected. Consumers using the custom `slot` snippet are untouched.

## Test plan

- [ ] `yarn test:ci` — full suite green (PaletteSlot 23, Palette 144)
- [ ] `yarn run check` — svelte-check clean
- [ ] `yarn build` — package builds, `publint` all good
- [ ] Named colors on a default palette show their name on hover (`title`) and to screen readers (`aria-label`); unnamed colors still announce their value

Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)