### PR TITLE
chore(deps): Update @untemps/utils to v4 and raise the Node engines floor

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
 	"dependencies": {
 		"@untemps/svelte-use-drop-outside": "^1.7.0",
 		"@untemps/svelte-use-tooltip": "^4.0.0",
-		"@untemps/utils": "^3.0.0"
+		"@untemps/utils": "^4.0.0"
 	},
 	"peerDependencies": {
 		"svelte": "^5.20.0"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 		}
 	},
 	"engines": {
-		"node": ">=22.12.0"
+		"node": ">=22.13.0"
 	},
 	"devDependencies": {
 		"@commitlint/cli": "^21.2.1",

--- a/src/lib/utils/__tests__/utils.test.ts
+++ b/src/lib/utils/__tests__/utils.test.ts
@@ -109,6 +109,19 @@ describe('utils', () => {
 				{ ...params, isCompact: true, compactColorIndices: [0, 4] },
 				[{ value: colors[0] }, { value: colors[4] }],
 			],
+			// Unsorted indices still yield source-order output (regression guard for @untemps/utils@4,
+			// whose extractByIndices now follows the indices order).
+			[
+				colors,
+				{ ...params, isCompact: true, compactColorIndices: [4, 0] },
+				[{ value: colors[0] }, { value: colors[4] }],
+			],
+			// Duplicate indices are de-duplicated (v3 semantics preserved under @untemps/utils@4).
+			[
+				colors,
+				{ ...params, isCompact: true, compactColorIndices: [0, 0, 4] },
+				[{ value: colors[0] }, { value: colors[4] }],
+			],
 			[colors, { ...params, isCompact: true, compactColorIndices: null }, []],
 			[colors, { ...params, allowDuplicates: false }, colorsObjects],
 			[[1, 1, 1], { ...params, allowDuplicates: false }, [{ value: 1 }]],

--- a/src/lib/utils/__tests__/utils.test.ts
+++ b/src/lib/utils/__tests__/utils.test.ts
@@ -109,14 +109,11 @@ describe('utils', () => {
 				{ ...params, isCompact: true, compactColorIndices: [0, 4] },
 				[{ value: colors[0] }, { value: colors[4] }],
 			],
-			// Unsorted indices still yield source-order output (regression guard for @untemps/utils@4,
-			// whose extractByIndices now follows the indices order).
 			[
 				colors,
 				{ ...params, isCompact: true, compactColorIndices: [4, 0] },
 				[{ value: colors[0] }, { value: colors[4] }],
 			],
-			// Duplicate indices are de-duplicated (v3 semantics preserved under @untemps/utils@4).
 			[
 				colors,
 				{ ...params, isCompact: true, compactColorIndices: [0, 0, 4] },

--- a/src/lib/utils/utils.ts
+++ b/src/lib/utils/utils.ts
@@ -82,7 +82,11 @@ export const calculateColors = (
 	let colors = transformColors(source)
 
 	if (params.isCompact) {
-		colors = extractByIndices(colors, params.compactColorIndices ?? [])
+		// @untemps/utils@4 made extractByIndices follow the `indices` order and keep duplicate
+		// indices; v3 returned source-order, de-duplicated output. Sort + unique to preserve that
+		// contract, keeping this mapping aligned with Palette's source-order `_compactPicked`.
+		const compactIndices = [...new Set(params.compactColorIndices ?? [])].sort((a, b) => a - b)
+		colors = extractByIndices(colors, compactIndices)
 	}
 	if (!params.allowDuplicates) {
 		colors = colors.filter(

--- a/src/lib/utils/utils.ts
+++ b/src/lib/utils/utils.ts
@@ -82,9 +82,6 @@ export const calculateColors = (
 	let colors = transformColors(source)
 
 	if (params.isCompact) {
-		// @untemps/utils@4 made extractByIndices follow the `indices` order and keep duplicate
-		// indices; v3 returned source-order, de-duplicated output. Sort + unique to preserve that
-		// contract, keeping this mapping aligned with Palette's source-order `_compactPicked`.
 		const compactIndices = [...new Set(params.compactColorIndices ?? [])].sort((a, b) => a - b)
 		colors = extractByIndices(colors, compactIndices)
 	}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1328,6 +1328,11 @@
   resolved "https://registry.yarnpkg.com/@untemps/utils/-/utils-3.2.1.tgz#4cd521f661f2376d48ad51e6f8b209bfe4c516a7"
   integrity sha512-6+lQBrEEtRd0s/sdz7Q+ooeSDbQ40wCRN/4hxJP978xSZ/m6T3H29QVHyDWIdx7Bbnk9nyrq6KPkAt68gt3wWg==
 
+"@untemps/utils@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@untemps/utils/-/utils-4.0.0.tgz#2bacdfd9e8932840d052b3f9d66ad9990029c21f"
+  integrity sha512-VgPKnC3WyW/8Zbm272EchVscewplIrwWGo6TLYhRA3unaJn2+/3pPF6nZPPnY0lpxVXflQVIaclgSfvh+awNug==
+
 "@vercel/nft@^1.3.2":
   version "1.10.2"
   resolved "https://registry.yarnpkg.com/@vercel/nft/-/nft-1.10.2.tgz#01aefaddc079a19bfe7d499872b2d6dd3cd729e1"


### PR DESCRIPTION
## Summary

Continues the dependency-currency work from #187. Most of that issue already landed on `beta` (jsdom 29, `@untemps/svelte-use-tooltip` 4, `prettier-plugin-svelte` 4, publint 0.3, Carbon 13 / 0.110, `cross-env` removed). This PR handles two of the three remaining items; the third (TypeScript 6 → 7) is intentionally deferred (see below).

## Changes

### `@untemps/utils` 3 → 4 (`409ffe5`)
v4's `extractByIndices` was rewritten to follow the `indices` order and to keep duplicate indices, whereas v3 returned **source-order, de-duplicated** output. `calculateColors` (compact mode) depends on the v3 contract, and it must stay index-aligned with `Palette`'s source-order `_compactPicked`, which the compact deletion path maps against by position.

Left unguarded, a consumer passing unsorted or duplicated `compactColorIndices` (a public prop) would get slots rendered in the wrong order / duplicated, and compact deletion could remove the wrong color — silently, since the signature is unchanged so `tsc` / `svelte-check` would not catch it.

The call site now sorts + uniques the indices, reproducing v3 output exactly. Two regression cases (unsorted `[4, 0]`, duplicated `[0, 0, 4]`) lock it in — they are red against raw v4 and green with the guard.

The v4 surface offers no value-adding drop-in refactor for this repo (`number/clamp` has different edge semantics, there is no color/hex module, and the case-insensitive dedup has no v4 equivalent), so the bump plus the required guard is the whole change. v4 also relaxes its own engine requirement (node ≥24 → ≥20) and keeps the export map identical, so subpath resolution is unaffected.

### Node engines floor 22.12 → 22.13 (`25016f3`)
`jsdom@29` requires `^20.19.0 || ^22.13.0 || >=24.0.0`; the previous `>=22.12.0` floor admitted Node 22.12, which jsdom does not support.

## TypeScript 6 → 7 — deferred (blocked by the Svelte toolchain)
TypeScript 7.0 is the native "tsgo" rewrite and ships **no stable programmatic compiler API until 7.1** (~Oct 2026). `svelte-check` and `svelte2tsx` import the `typescript` module as a library and crash under TS 7 (sveltejs/language-tools#3063); the latest `svelte-check` / `svelte2tsx` cap their `typescript` peer at `^5 || ^6`. `yarn check` and `yarn package` (`.d.ts` emit) are exactly those code paths, so `typescript` stays at `^6.0.3` until the Svelte language-tools support TS 7.

## Test plan
- [x] `yarn run check` — 0 errors, 0 warnings
- [x] `yarn test:ci` — 1209 passed (incl. 2 new regression cases)
- [x] `yarn build` — `vite build` + `svelte-package` + `publint` ("All good!")
- [x] `yarn lint` — prettier clean

Refs #187
