### PR TITLE
test: Assert async slot count directly instead of an un-awaited waitFor

### DIFF
--- a/src/lib/components/__tests__/Palette.test.ts
+++ b/src/lib/components/__tests__/Palette.test.ts
@@ -72,7 +72,7 @@ test('Displays as many color slots as set in async mode', async () => {
 	})
 
 	cells = await screen.findAllByTestId('__palette-cell__')
-	waitFor(() => expect(cells).toHaveLength(3))
+	expect(cells).toHaveLength(3)
 })
 
 test('Discards a stale async colors promise that settles after a newer one', async () => {


### PR DESCRIPTION
## Summary

Issue #188 reported two tests that call `waitFor(...)` without `await`, so the
assertion inside is scheduled but discarded after the test has already resolved —
making them structurally incapable of failing. Auditing the tree against the
current `beta`, only one of the two spots is still affected; the other was already
fixed incidentally on `beta`.

## What was already fixed on `beta`

`PaletteInput.test.ts` — *"Enables submit button when input color is valid"* now
types `ff` then `ff00` (ending at the valid `#ffff00`) and already uses
`await waitFor(...)`, so it genuinely exercises the enabled state. No change needed.

## Changes

`Palette.test.ts` — *"Displays as many color slots as set in async mode"*:

```diff
 cells = await screen.findAllByTestId('__palette-cell__')
-waitFor(() => expect(cells).toHaveLength(3))
+expect(cells).toHaveLength(3)
```

`cells` is an already-resolved, frozen array, so retrying the callback can never
change the outcome — and because the `waitFor` was not awaited, its rejection was
swallowed and the length assertion never ran. Assert directly on the awaited
`findAllByTestId` result, which is what the test already synchronised on, so the
count is now genuinely enforced (and consistent with the synchronous
*"Displays as many color slots as set"* test right above it).

A `grep` of the whole `src/` tree confirms this was the last remaining un-awaited
`waitFor`, and that no `findBy*` call is left un-awaited.

## Out of scope (deferred)

The issue's third proposal — adopting `eslint-plugin-testing-library`'s
`await-async-utils` rule — requires introducing ESLint to a repo that currently
has none (`lint` is `prettier --check .`). The issue author flagged it as "worth
considering separately"; it should land as its own change.

## Test plan

- [x] `yarn test:ci` — 433 passed
- [x] `yarn lint` — Prettier clean
- [x] `yarn run check` — svelte-check: 0 errors, 0 warnings
- [x] `yarn build` — build + publint OK

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)