### PR TITLE
test(use-deletion): Cover the action dispatch and update lifecycle

### DIFF
--- a/src/lib/components/__tests__/useDeletion.test.ts
+++ b/src/lib/components/__tests__/useDeletion.test.ts
@@ -1,0 +1,296 @@
+import { useTooltip } from '@untemps/svelte-use-tooltip'
+import { useDropOutside } from '@untemps/svelte-use-drop-outside'
+
+import useDeletion from '../useDeletion'
+
+import { NONE, TOOLTIP, DROP } from '../../enums/PaletteDeletionMode'
+
+import type { DeletionMode } from '../../types'
+
+vi.mock('@untemps/svelte-use-tooltip', () => ({
+	useTooltip: vi.fn(() => ({ update: vi.fn(), destroy: vi.fn() })),
+}))
+
+vi.mock('@untemps/svelte-use-drop-outside', () => ({
+	useDropOutside: vi.fn(() => ({ update: vi.fn(), destroy: vi.fn() })),
+}))
+
+const useTooltipMock = vi.mocked(useTooltip)
+const useDropOutsideMock = vi.mocked(useDropOutside)
+
+type AnyMock = { mock: { calls: any[][]; results: { value: any }[] } }
+
+const tooltipArgs = (call = 0) => (useTooltipMock as unknown as AnyMock).mock.calls[call]
+const dropArgs = (call = 0) => (useDropOutsideMock as unknown as AnyMock).mock.calls[call]
+const tooltipInstance = (call = 0) => (useTooltipMock as unknown as AnyMock).mock.results[call].value
+const dropInstance = (call = 0) => (useDropOutsideMock as unknown as AnyMock).mock.results[call].value
+
+const mount = (node: HTMLElement, parameter: Parameters<typeof useDeletion>[1]) => {
+	return useDeletion(node, parameter) as { update: (p: unknown) => void; destroy: () => void }
+}
+
+const withSlotButton = () => {
+	const node = document.createElement('div')
+	const slotButton = document.createElement('button')
+	slotButton.setAttribute('data-testid', '__palette-slot__')
+	slotButton.textContent = 'slot'
+	node.appendChild(slotButton)
+	return { node, slotButton }
+}
+
+beforeEach(() => {
+	vi.clearAllMocks()
+})
+
+describe('creation', () => {
+	test('Creates a tooltip action for TOOLTIP with the default content selector', () => {
+		const node = document.createElement('div')
+		mount(node, { deletionMode: TOOLTIP, tooltipClassName: 'custom-tooltip' })
+
+		expect(useTooltipMock).toHaveBeenCalledTimes(1)
+		expect(useDropOutsideMock).not.toHaveBeenCalled()
+
+		const [passedNode, options] = tooltipArgs()
+		expect(passedNode).toBe(node)
+		expect(options.contentSelector).toBe('#tooltip-template')
+		expect(options.containerClassName).toBe('custom-tooltip')
+	})
+
+	test('Resolves a custom tooltip content selector', () => {
+		const node = document.createElement('div')
+		mount(node, { deletionMode: TOOLTIP, tooltipContentSelector: '#my-template' })
+
+		expect(tooltipArgs()[1].contentSelector).toBe('#my-template')
+	})
+
+	test('Wires onDelete into the tooltip click action', () => {
+		const node = document.createElement('div')
+		const onDelete = vi.fn()
+		mount(node, { deletionMode: TOOLTIP, onDelete })
+
+		tooltipArgs()[1].contentActions['*'].callback()
+		expect(onDelete).toHaveBeenCalledTimes(1)
+	})
+
+	test('Falls back to a no-op tooltip callback when onDelete is omitted', () => {
+		const node = document.createElement('div')
+		mount(node, { deletionMode: TOOLTIP })
+
+		expect(() => tooltipArgs()[1].contentActions['*'].callback()).not.toThrow()
+	})
+
+	test('Creates a drop action for DROP with a data-testid-stripped drag image clone', () => {
+		const { node, slotButton } = withSlotButton()
+		const onDelete = vi.fn()
+		mount(node, { deletionMode: DROP, areaSelector: '.my-area', onDelete })
+
+		expect(useDropOutsideMock).toHaveBeenCalledTimes(1)
+		expect(useTooltipMock).not.toHaveBeenCalled()
+
+		const [passedNode, options] = dropArgs()
+		expect(passedNode).toBe(node)
+		expect(options.areaSelector).toBe('.my-area')
+		expect(options.onDropOutside).toBe(onDelete)
+		expect(options.dragImage).toBeInstanceOf(HTMLElement)
+		expect(options.dragImage).not.toBe(slotButton)
+		expect(options.dragImage.hasAttribute('data-testid')).toBe(false)
+		expect(slotButton.getAttribute('data-testid')).toBe('__palette-slot__')
+	})
+
+	test('Defaults the drop area selector to .palette', () => {
+		const { node } = withSlotButton()
+		mount(node, { deletionMode: DROP })
+
+		expect(dropArgs()[1].areaSelector).toBe('.palette')
+	})
+
+	test('Passes an undefined drag image for DROP when no slot button is present', () => {
+		const node = document.createElement('div')
+		mount(node, { deletionMode: DROP })
+
+		expect(dropArgs()[1].dragImage).toBeUndefined()
+	})
+
+	test('Creates no action for NONE', () => {
+		const node = document.createElement('div')
+		mount(node, { deletionMode: NONE })
+
+		expect(useTooltipMock).not.toHaveBeenCalled()
+		expect(useDropOutsideMock).not.toHaveBeenCalled()
+	})
+
+	test('Creates no action for an unknown mode', () => {
+		const node = document.createElement('div')
+		mount(node, { deletionMode: 'bogus' as DeletionMode })
+
+		expect(useTooltipMock).not.toHaveBeenCalled()
+		expect(useDropOutsideMock).not.toHaveBeenCalled()
+	})
+})
+
+describe('update — mode changes', () => {
+	test('Destroys the previous action once and creates the new one when the mode changes', () => {
+		const { node } = withSlotButton()
+		const action = mount(node, { deletionMode: TOOLTIP })
+		const tooltip = tooltipInstance()
+
+		action.update({ deletionMode: DROP })
+
+		expect(tooltip.destroy).toHaveBeenCalledTimes(1)
+		expect(useTooltipMock).toHaveBeenCalledTimes(1)
+		expect(useDropOutsideMock).toHaveBeenCalledTimes(1)
+	})
+
+	test('Tears the action down without rebuilding when the mode changes to NONE', () => {
+		const node = document.createElement('div')
+		const action = mount(node, { deletionMode: TOOLTIP })
+		const tooltip = tooltipInstance()
+
+		action.update({ deletionMode: NONE })
+
+		expect(tooltip.destroy).toHaveBeenCalledTimes(1)
+		expect(useTooltipMock).toHaveBeenCalledTimes(1)
+		expect(useDropOutsideMock).not.toHaveBeenCalled()
+	})
+
+	test('Does not resurrect the mount-time mode when update receives a falsy mode', () => {
+		const node = document.createElement('div')
+		const action = mount(node, { deletionMode: TOOLTIP })
+		expect(useTooltipMock).toHaveBeenCalledTimes(1)
+		const tooltip = tooltipInstance()
+
+		action.update({ deletionMode: undefined })
+
+		expect(tooltip.destroy).toHaveBeenCalledTimes(1)
+		expect(useTooltipMock).toHaveBeenCalledTimes(1)
+	})
+
+	test('Builds the new action when the mode turns on from NONE', () => {
+		const node = document.createElement('div')
+		const action = mount(node, { deletionMode: NONE })
+
+		action.update({ deletionMode: TOOLTIP })
+
+		expect(useTooltipMock).toHaveBeenCalledTimes(1)
+	})
+
+	test('Tracks the new mode so a later same-mode update reconciles instead of rebuilding', () => {
+		const node = document.createElement('div')
+		const action = mount(node, { deletionMode: DROP })
+		action.update({ deletionMode: TOOLTIP })
+		const tooltip = tooltipInstance()
+		expect(useTooltipMock).toHaveBeenCalledTimes(1)
+
+		action.update({ deletionMode: TOOLTIP, onDelete: vi.fn() })
+
+		expect(useTooltipMock).toHaveBeenCalledTimes(1)
+		expect(tooltip.destroy).not.toHaveBeenCalled()
+		expect(tooltip.update).toHaveBeenCalledTimes(1)
+	})
+
+	test('Carries prior options into the action built on a mode change', () => {
+		const { node } = withSlotButton()
+		const onDelete = vi.fn()
+		const action = mount(node, { deletionMode: TOOLTIP, onDelete })
+
+		action.update({ deletionMode: DROP })
+
+		expect(dropArgs()[1].onDropOutside).toBe(onDelete)
+	})
+
+	test('Does not create any action when update runs on a NONE action', () => {
+		const node = document.createElement('div')
+		const action = mount(node, { deletionMode: NONE })
+
+		expect(() => action.update({ deletionMode: NONE })).not.toThrow()
+		expect(useTooltipMock).not.toHaveBeenCalled()
+		expect(useDropOutsideMock).not.toHaveBeenCalled()
+	})
+})
+
+describe('update — same mode, TOOLTIP (reconciles in place)', () => {
+	test('Reconciles in place through the underlying action instead of rebuilding', () => {
+		const node = document.createElement('div')
+		const action = mount(node, { deletionMode: TOOLTIP, onDelete: vi.fn() })
+		const tooltip = tooltipInstance()
+
+		action.update({ deletionMode: TOOLTIP, onDelete: vi.fn() })
+
+		expect(useTooltipMock).toHaveBeenCalledTimes(1)
+		expect(tooltip.destroy).not.toHaveBeenCalled()
+		expect(tooltip.update).toHaveBeenCalledTimes(1)
+	})
+
+	test('Forwards the new onDelete closure to the underlying tooltip action', () => {
+		const node = document.createElement('div')
+		const onDelete1 = vi.fn()
+		const onDelete2 = vi.fn()
+		const action = mount(node, { deletionMode: TOOLTIP, onDelete: onDelete1 })
+		const tooltip = tooltipInstance()
+
+		action.update({ deletionMode: TOOLTIP, onDelete: onDelete2 })
+
+		expect(tooltip.update).toHaveBeenCalledTimes(1)
+		const forwarded = tooltip.update.mock.calls[0][0]
+		forwarded.contentActions['*'].callback()
+		expect(onDelete2).toHaveBeenCalledTimes(1)
+		expect(onDelete1).not.toHaveBeenCalled()
+	})
+})
+
+describe('update — same mode, DROP (rebuilt safely)', () => {
+	test('Rebuilds the drop action and accumulates options over the previous state', () => {
+		const { node } = withSlotButton()
+		const onDelete = vi.fn()
+		const action = mount(node, { deletionMode: DROP, areaSelector: '.first' })
+		const firstDrop = dropInstance(0)
+
+		action.update({ deletionMode: DROP, areaSelector: '.second' })
+		const secondDrop = dropInstance(1)
+		action.update({ deletionMode: DROP, onDelete })
+
+		expect(useDropOutsideMock).toHaveBeenCalledTimes(3)
+		expect(firstDrop.destroy).toHaveBeenCalledTimes(1)
+		expect(secondDrop.destroy).toHaveBeenCalledTimes(1)
+
+		const lastArgs = dropArgs(2)[1]
+		expect(lastArgs.areaSelector).toBe('.second')
+		expect(lastArgs.onDropOutside).toBe(onDelete)
+	})
+})
+
+describe('defensive parameter handling', () => {
+	test('Creates no action and does not throw when mounted without a parameter', () => {
+		const node = document.createElement('div')
+
+		expect(() => mount(node, undefined as unknown as Parameters<typeof useDeletion>[1])).not.toThrow()
+		expect(useTooltipMock).not.toHaveBeenCalled()
+		expect(useDropOutsideMock).not.toHaveBeenCalled()
+	})
+
+	test('Does not throw when update runs without a parameter', () => {
+		const node = document.createElement('div')
+		const action = mount(node, undefined as unknown as Parameters<typeof useDeletion>[1])
+
+		expect(() => action.update(undefined)).not.toThrow()
+	})
+})
+
+describe('destroy', () => {
+	test('Destroys the underlying action', () => {
+		const node = document.createElement('div')
+		const action = mount(node, { deletionMode: TOOLTIP })
+		const tooltip = tooltipInstance()
+
+		action.destroy()
+
+		expect(tooltip.destroy).toHaveBeenCalledTimes(1)
+	})
+
+	test('Does not throw when destroying a NONE action', () => {
+		const node = document.createElement('div')
+		const action = mount(node, { deletionMode: NONE })
+
+		expect(() => action.destroy()).not.toThrow()
+	})
+})

--- a/src/lib/components/useDeletion.ts
+++ b/src/lib/components/useDeletion.ts
@@ -59,7 +59,7 @@ const createAction = (
 		case TOOLTIP:
 			return useTooltip(node, buildTooltipOptions(options)) as unknown as DeletionAction
 		case DROP:
-			return useDropOutside(node, buildDropOptions(node, options)) as DeletionAction
+			return useDropOutside(node, buildDropOptions(node, options)) as unknown as DeletionAction
 		default:
 			return null
 	}

--- a/src/lib/components/useDeletion.ts
+++ b/src/lib/components/useDeletion.ts
@@ -18,52 +18,69 @@ export interface UseDeletionParameter extends UseDeletionOptions {
 	deletionMode?: DeletionMode
 }
 
-const createAction = (node: HTMLElement, deletionMode: DeletionMode | undefined, options: UseDeletionOptions) => {
+type DeletionAction = { update?: (options: unknown) => void; destroy?: () => void } | null
+
+const buildTooltipOptions = (options: UseDeletionOptions) => ({
+	contentSelector: options.tooltipContentSelector || '#tooltip-template',
+	contentActions: {
+		'*': {
+			eventType: 'click',
+			callback: options.onDelete ?? (() => {}),
+			closeOnCallback: true,
+		},
+	},
+	containerClassName: options.tooltipClassName,
+	portal: false,
+	showOn: ['mouseenter'],
+	hideOn: ['mouseleave'],
+})
+
+const buildDropOptions = (node: HTMLElement, options: UseDeletionOptions) => {
+	const slotButton = node.querySelector('[data-testid="__palette-slot__"]')
+	const dragImage = slotButton ? (slotButton.cloneNode(true) as HTMLElement) : undefined
+	if (dragImage) {
+		dragImage.removeAttribute('data-testid')
+	}
+	return {
+		areaSelector: options.areaSelector || '.palette',
+		animate: true,
+		dragImage,
+		dragHandleCentered: true,
+		onDropOutside: options.onDelete,
+	}
+}
+
+const createAction = (
+	node: HTMLElement,
+	deletionMode: DeletionMode | undefined,
+	options: UseDeletionOptions
+): DeletionAction => {
 	switch (deletionMode) {
-		case TOOLTIP: {
-			return useTooltip(node, {
-				contentSelector: options.tooltipContentSelector || '#tooltip-template',
-				contentActions: {
-					'*': {
-						eventType: 'click',
-						callback: options.onDelete ?? (() => {}),
-						closeOnCallback: true,
-					},
-				},
-				containerClassName: options.tooltipClassName,
-				portal: false,
-				showOn: ['mouseenter'],
-				hideOn: ['mouseleave'],
-			})
-		}
-		case DROP: {
-			const slotButton = node.querySelector('[data-testid="__palette-slot__"]')
-			const dragImage = slotButton ? (slotButton.cloneNode(true) as HTMLElement) : undefined
-			if (dragImage) {
-				dragImage.removeAttribute('data-testid')
-			}
-			return useDropOutside(node, {
-				areaSelector: options.areaSelector || '.palette',
-				animate: true,
-				dragImage,
-				dragHandleCentered: true,
-				onDropOutside: options.onDelete,
-			})
-		}
+		case TOOLTIP:
+			return useTooltip(node, buildTooltipOptions(options)) as unknown as DeletionAction
+		case DROP:
+			return useDropOutside(node, buildDropOptions(node, options)) as DeletionAction
 		default:
 			return null
 	}
 }
 
 const useDeletion: Action<HTMLElement, UseDeletionParameter> = (node, parameter) => {
-	const { deletionMode, ...options } = parameter ?? {}
+	let { deletionMode, ...options } = parameter ?? {}
 	let action = createAction(node, deletionMode, options)
 
 	return {
 		update: (newParameter) => {
 			const { deletionMode: newDeletionMode, ...newOptions } = newParameter ?? {}
-			action?.destroy?.()
-			action = createAction(node, newDeletionMode || deletionMode, { ...options, ...newOptions })
+			const nextOptions = { ...options, ...newOptions }
+			if (action && newDeletionMode === deletionMode && newDeletionMode === TOOLTIP) {
+				action.update?.(buildTooltipOptions(nextOptions))
+			} else {
+				action?.destroy?.()
+				action = createAction(node, newDeletionMode, nextOptions)
+			}
+			deletionMode = newDeletionMode
+			options = nextOptions
 		},
 		destroy: () => action?.destroy?.(),
 	}


### PR DESCRIPTION
## Summary

`useDeletion` — the internal Svelte action Palette uses to wire up tooltip/drop deletion — had no dedicated test. Its `update` path was only reached incidentally through `Palette`'s deletion tests, none of which asserted anything about it, so the latent flaws it carried went unobserved. This adds a direct unit test against a bare node (both dependencies mocked) and fixes the three flaws it surfaces — two latent, one with real user-facing impact.

## Changes

- **`refactor(use-deletion)`** — three fixes on the `update` path, plus a cast cleanup. The first two update-path fixes are **latent hardening**: `Palette` never reaches them in practice — every `DeletionMode` value is a truthy string (so the `|| deletionMode` fallback never fired), and `Palette` re-passes the full option set on every render (so merging over the mount-time snapshot vs. the previous state yields the same result) — but they leave the reusable action correct in isolation. The third is the one with real user-facing impact.
  - _(latent)_ Dropped the `newDeletionMode || deletionMode` fallback that resurrected the mount-time mode whenever `update` received a falsy mode instead of tearing the action down.
  - _(latent)_ Options now merge over the **previous** state rather than the mount-time snapshot.
  - _(user-facing)_ An unchanged **TOOLTIP** now reconciles through the tooltip dependency's own `update()` instead of a destroy+rebuild, so a re-render no longer collapses a live bubble mid-hover.
  - _(cleanup)_ Unified the two `createAction` return casts on the same `as unknown as DeletionAction` form.
- **`test(use-deletion)`** — a new `__tests__/useDeletion.test.ts` (23 tests) covering mode dispatch (TOOLTIP/DROP/NONE/unknown), the resolved tooltip content selector, the `data-testid`-stripped drag-image clone (and its `undefined` path), in-place TOOLTIP reconciliation, safe DROP rebuild with option carry-over, honoring an explicit falsy mode change, and destroy pass-through. Five assertions are red-green (verified failing against the previous implementation): the falsy-mode teardown, the new-mode tracking for a later same-mode update, the in-place TOOLTIP reconcile, the forwarded `onDelete` closure, and the DROP rebuild with option carry-over.

## Note — DROP stays on destroy+recreate (intentional)

The issue suggested routing **both** dependencies through their own `update()`. TOOLTIP is safe: `@untemps/svelte-use-tooltip`'s `update()` clears its content observer before re-registering. `@untemps/svelte-use-drop-outside`'s `update()`, however, spins up a fresh `MutationObserver` **without** clearing the previous one (only `destroy()` clears it), so reconciling DROP in place would orphan an observer on every re-render. DROP therefore keeps the destroy+recreate path, which does clear. Worth a follow-up fix upstream in `svelte-use-drop-outside`.

## Test plan

- [x] `yarn test:ci` — full suite green; `useDeletion.ts` fully exercised
- [x] Red-green confirmed: the 5 behaviour tests fail against the previous implementation, pass against the fix
- [x] `yarn run check` — svelte-check 0 errors
- [x] `yarn lint` — prettier clean
- [x] `yarn build` — build + publint pass
- [x] No change to `Palette`'s public behaviour (all existing Palette tests unchanged and passing)

Closes #186
