### PR TITLE
ci: Validate pull requests before merge

### DIFF
--- a/.github/actions/validate/action.yml
+++ b/.github/actions/validate/action.yml
@@ -1,4 +1,4 @@
-name: 'validate'
+name: 'Validate'
 description: 'Install dependencies and run the quality gate: lint, type check, tests and build'
 inputs:
     node-version:

--- a/.github/actions/validate/action.yml
+++ b/.github/actions/validate/action.yml
@@ -1,0 +1,25 @@
+name: 'validate'
+description: 'Install dependencies and run the quality gate: lint, type check, tests and build'
+inputs:
+    node-version:
+        description: 'Node version used to run the quality gate'
+        required: false
+        default: '24'
+runs:
+    using: 'composite'
+    steps:
+        - uses: actions/setup-node@v6
+          with:
+              node-version: ${{ inputs.node-version }}
+        - run: yarn install --frozen-lockfile
+          shell: bash
+          env:
+              HUSKY: '0'
+        - run: yarn lint
+          shell: bash
+        - run: yarn run check
+          shell: bash
+        - run: yarn test:ci
+          shell: bash
+        - run: yarn build
+          shell: bash

--- a/.github/actions/validate/action.yml
+++ b/.github/actions/validate/action.yml
@@ -11,6 +11,7 @@ runs:
         - uses: actions/setup-node@v6
           with:
               node-version: ${{ inputs.node-version }}
+              cache: 'yarn'
         - run: yarn install --frozen-lockfile
           shell: bash
           env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ permissions:
     contents: read
 jobs:
     validate:
+        name: 'Validate'
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,3 +17,4 @@ jobs:
             - uses: codecov/codecov-action@v5
               with:
                   files: coverage/lcov.info
+                  token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: 'ci'
+name: 'CI'
 on:
     pull_request:
     workflow_dispatch:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,3 +14,6 @@ jobs:
         steps:
             - uses: actions/checkout@v6
             - uses: ./.github/actions/validate
+            - uses: codecov/codecov-action@v5
+              with:
+                  files: coverage/lcov.info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: 'ci'
+on:
+    pull_request:
+    workflow_dispatch:
+concurrency:
+    group: ci-${{ github.ref }}
+    cancel-in-progress: true
+permissions:
+    contents: read
+jobs:
+    validate:
+        runs-on: ubuntu-latest
+        env:
+            HUSKY: '0'
+        steps:
+            - uses: actions/checkout@v6
+            - uses: actions/setup-node@v6
+              with:
+                  node-version: '24'
+            - run: yarn install --frozen-lockfile
+            - run: yarn lint
+            - run: yarn run check
+            - run: yarn test:ci
+            - run: yarn build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,15 +10,6 @@ permissions:
 jobs:
     validate:
         runs-on: ubuntu-latest
-        env:
-            HUSKY: '0'
         steps:
             - uses: actions/checkout@v6
-            - uses: actions/setup-node@v6
-              with:
-                  node-version: '24'
-            - run: yarn install --frozen-lockfile
-            - run: yarn lint
-            - run: yarn run check
-            - run: yarn test:ci
-            - run: yarn build
+            - uses: ./.github/actions/validate

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,7 @@ jobs:
               with:
                   node-version: '24'
             - run: yarn install --frozen-lockfile
+            - run: yarn lint
             - run: yarn test:ci
             - run: yarn run check
             - run: yarn build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,3 +29,4 @@ jobs:
             - uses: codecov/codecov-action@v5
               with:
                   files: coverage/lcov.info
+                  token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,14 +18,7 @@ jobs:
             - uses: actions/checkout@v6
               with:
                   fetch-depth: 0
-            - uses: actions/setup-node@v6
-              with:
-                  node-version: '24'
-            - run: yarn install --frozen-lockfile
-            - run: yarn lint
-            - run: yarn test:ci
-            - run: yarn run check
-            - run: yarn build
+            - uses: ./.github/actions/validate
             - run: npx semantic-release
               env:
                   GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,7 @@ permissions:
     issues: write
 jobs:
     publish:
+        name: 'Publish'
         runs-on: ubuntu-latest
         env:
             HUSKY: '0'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: 'publish'
+name: 'Publish'
 on:
     push:
         branches:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,9 @@ on:
         branches:
             - main
             - beta
+concurrency:
+    group: publish-${{ github.ref }}
+    cancel-in-progress: false
 permissions:
     contents: write
     id-token: write


### PR DESCRIPTION
## Summary

`.github/workflows/publish.yml` was the only workflow in the repository and it triggers exclusively on `push` to `main` and `beta`. Nothing ran on a pull request, so a PR could be reviewed and merged with a red suite and the failure would only surface on a merge commit that had already landed. Fork PRs got no validation at all, since `push` never fires for them.

This adds a `CI` workflow that validates every pull request, closes a second gap (`yarn lint` was defined in `package.json` but never invoked by any workflow), and factors the quality gate into a single shared composite action so the two workflows cannot drift apart.

## Changes

- **`.github/actions/validate/action.yml` (new)** — a composite action owning the quality gate: `setup-node` → `yarn install --frozen-lockfile` → `yarn lint` → `yarn run check` → `yarn test:ci` → `yarn build`, cheapest step first so a formatting slip does not wait on a full coverage run. The Node version is an input defaulting to `'24'`. `setup-node` is configured with `cache: 'yarn'`.
- **`.github/workflows/ci.yml` (new)** — `Validate` job triggered on `pull_request` and `workflow_dispatch`, reduced to `checkout` + the composite action + the Codecov upload.
  - `concurrency` keyed on `github.ref` with `cancel-in-progress`, so rapid pushes to a PR do not stack redundant runs.
  - `permissions: contents: read` — least privilege; unlike the publish job, CI needs no write scopes.
- **`.github/workflows/publish.yml`** — its four inline validation steps are replaced by the same composite action, so it now also runs `yarn lint`, which no workflow had ever invoked. Formatting was previously enforced only by the local husky hook, which auto-writes rather than checks, so automation could never fail on a formatting violation. A `concurrency` group is added, and the Codecov step gains the token it has silently needed since 2024 (see below). `semantic-release` is untouched.

## Design notes

**Composite action rather than a reusable workflow.** `workflow_call` shares a *job*, so it runs on its own runner — `publish.yml` would then have to either re-run the build or shuttle `coverage/lcov.info` and `dist/` across as artifacts. Sharing *steps* keeps `publish` a single job, so `npx semantic-release` and `codecov/codecov-action` still find the `dist/` and coverage produced moments earlier on the same runner. The release pipeline's behaviour is unchanged.

**What deliberately stays outside the shared action.** `actions/checkout` must run before a local `uses: ./...` can be resolved at all, and it differs per caller anyway: `publish` needs `fetch-depth: 0` for semantic-release to compute the next version, `ci` does not. `HUSKY: '0'` remains pinned at job level in `publish.yml` because `@semantic-release/git` commits during the release and must not fire the husky hooks; the composite action additionally sets it on its own install step so it is self-contained.

**Dependency caching.** `cache: 'yarn'` on `setup-node` keys the cache on the `yarn.lock` hash, which composes safely with `--frozen-lockfile`. This mattered little when the gate ran on two branches only; it matters now that the same install runs on every push to every open PR. The first run after this lands is cold.

**Coverage on pull requests — and a pre-existing outage this uncovered.** `yarn test:ci` is `vitest run --coverage`, so every PR was already paying the instrumentation cost and then discarding `coverage/lcov.info`. `ci.yml` now uploads it, which is where diff coverage is most actionable.

Adding the step surfaced that **the Codecov upload in `publish.yml` has been failing silently since February 2024**. The live run on this branch shows the cause:

```
info  -- Found 1 coverage files to report
info  -- Upload queued for processing complete
error -- Upload queued for processing failed: {"message":"Token required because branch is protected"}
##[end-action ...;outcome=success;conclusion=success]
```

Tokenless uploads are no longer accepted for this repository, and because `fail_ci_if_error` defaults to `false` in v5 the step reports `success` regardless. The step conclusion therefore carries no information about whether anything was actually uploaded — which is why this went unnoticed. Confirmed against the service rather than the job status: the Codecov API's most recent commit for the repo is `4196a71` (`chore(deps): Bump ip from 2.0.0 to 2.0.1 (#96)`, 2024-02-29), with totals frozen at 23 files / 1168 lines / 98.88%. The README's Codecov badge has been showing 2024 data ever since.

Both uploads now pass `token: ${{ secrets.CODECOV_TOKEN }}`, and the secret has been added. **Verified end to end**: the run on `bfd6d70` reports `Token length: 36`, `Upload queued for processing complete`, and no `processing failed` line; the Codecov API now lists `bfd6d70` (2026-08-26, `state=complete`) as its most recent commit, where it had been stuck on a 2024-02-29 commit for two years. Wiring both call sites identically keeps them from drifting, so `publish.yml` is repaired by the same change.

Expect the README badge to **drop from 98.88% to about 90%**. That is not a regression: 98.88% was a stale 2024 figure measured against 23 files / 1168 lines of the pre-6.0 codebase. The first honest measurement in two years is 90.41% across 28 files / 876 lines.

Remaining notes on the step:

- `fail_ci_if_error` is deliberately left at its `false` default. Fork PRs cannot read secrets, so their uploads will always fail; a coverage service must not be able to red the quality gate. The trade-off is precisely the silent-failure mode described above, so treat the Codecov dashboard, not the job status, as the source of truth.
- Codecov will now post `codecov/project` and `codecov/patch` statuses on PRs. There is no `codecov.yml`, so these are the defaults. They block nothing unless made required.
- The upload only runs on a green gate, since steps stop at the first failure. Coverage for a commit whose build is broken is not published.

The step is not folded into the composite action: uploading to a third-party reporting service is a side effect, not a gate, and `publish.yml` deliberately runs its upload *after* `semantic-release`.

**Serialised publishes.** `publish.yml` had no `concurrency` group, so two merges landing on `beta` within a minute would run `semantic-release` concurrently and race on tag creation and the npm version bump. `cancel-in-progress` is `false` here, unlike in `ci.yml`: a cancelled validation costs nothing, but a `semantic-release` killed mid-flight can leave a tag pushed without a published package, or a GitHub release without its `dist/index.js` asset. Serialising is the goal; cancelling is the hazard.

**No `push` trigger on `ci.yml`.** `publish.yml` already runs the same gate on `main`/`beta` before releasing, so a `push` trigger here would run the entire suite twice per release push for no added signal.

**No new README badge.** Shields reads the latest run on the default branch, and a PR-only workflow never runs on `main`, so a `ci.yml` badge would render "no status" permanently. The existing badge continues to point at `publish.yml`.

## Test plan

- [x] `yarn lint` — all matched files use Prettier code style, `.github/` included
- [x] `yarn run check` — 215 files, 0 errors, 0 warnings
- [x] `yarn test:ci` — all tests passing
- [x] `yarn build` — vite build + svelte-package + publint all good
- [x] Workflows and composite action parse as valid YAML with the expected triggers, permissions and step structure, and every composite `run` step declares its `shell`
- [x] Cache confirmed active in the live run: `Cache saved with the key: node-cache-Linux-x64-yarn-<lockfile-hash>`
- [x] Codecov upload traced end to end in the live run rather than trusted from the step conclusion, which is what exposed the 2024 outage described above — and re-verified against the Codecov API after the token was added, which is what proves the repair
- [x] `Validate` confirmed to be the exact check name the workflow publishes, so the required status check on `main`/`beta` matches a context that actually reports
- [x] This PR is the live test: the `Validate` job triggered on `pull_request` and passed on GitHub, first with inline steps, again after the composite-action extraction, and again with caching and the coverage upload

## Manual configuration — done

Both out-of-code steps this PR depended on are in place and verified:

- **`CODECOV_TOKEN` repository secret** — added. Confirmed working by the run on `bfd6d70` and by fresh data landing in the Codecov API.
- **Branch protection** — `Validate` is a required status check on both `main` and `beta`. The context name reported by the workflow is exactly `Validate`, so it matches the required context; this PR reports `mergeStateStatus: CLEAN`.

## Deliberately out of scope

- **No Node version matrix.** The gate runs on Node 24 only, so `engines.node` (`>=22.13.0`) is not exercised at its lower bound. Accepted: a matrix would double the runner cost for a library whose only Node-version sensitivity is its tooling. It also matters now that branch protection is live — a matrix would rename the check to `Validate (24)` and silently break the required context. The composite action keeps its `node-version` input as a single-point override should this ever be revisited.
- **No `timeout-minutes`.** Both jobs inherit the 360-minute default.

This PR is scoped to closing the validation gap, not to exhaustive workflow hardening.

Refs #179
