### PR TITLE
chore: Align the pre-commit hook with the CI lint check

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-yarn run check && yarn test:ci && yarn prettier
+yarn run check && yarn test:ci && yarn lint

--- a/package.json
+++ b/package.json
@@ -124,8 +124,8 @@
 		"test": "vitest watch --coverage",
 		"test:ci": "vitest run --coverage",
 		"lint": "prettier --check .",
+		"lint:fix": "prettier --write .",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
-		"prettier": "prettier \"*/**/*.{js,ts,svelte}\" --ignore-path ./.prettierignore --write && git add -u && git status",
 		"prepare": "husky"
 	}
 }


### PR DESCRIPTION
## Summary

Issue #193 reported that the `lint` script was never executed by CI, and flagged a secondary problem: the pre-commit hook and the CI check do not cover the same files.

The primary half is already fixed — #267 introduced the `.github/actions/validate` composite action, which runs `yarn lint` first, and both `ci.yml` (on `pull_request`) and `publish.yml` (on push) consume it. No workflow change is needed here.

This PR closes the remaining gap: the local hook now runs the exact command CI runs, so a clean commit is real evidence that the `Validate` job will pass.

## The gap

`.husky/pre-commit` ended with `yarn prettier`:

```
prettier "*/**/*.{js,ts,svelte}" --ignore-path ./.prettierignore --write && git add -u && git status
```

Two divergences from CI's `prettier --check .`:

1. **Scope** — the glob matched only `.js`/`.ts`/`.svelte` files nested at least one directory deep. Root-level files and every `.md`, `.json`, `.yml` and `.css` in the repo were never formatted locally, but are checked by CI.
2. **Semantics** — `--write` followed by `git add -u` can never fail. It silently rewrote and staged files instead of reporting a violation, and `git add -u` swept every modified tracked file into the commit, including unrelated ones.

## Changes

- `.husky/pre-commit` — run `yarn lint` instead of `yarn prettier`, so local and CI execute the identical command
- `package.json` — replace the narrow-glob `prettier` script with `lint:fix` (`prettier --write .`), the one-liner that repairs whatever `yarn lint` reports

Contributor-facing behaviour change: a commit with a formatting violation now fails loudly instead of being silently rewritten. Run `yarn lint:fix` to repair.

## Test plan

- [x] Red — appended unformatted markdown to root-level `README.md`, then ran the old glob (`prettier "*/**/*.{js,ts,svelte}" --check`): passed, blind to the violation
- [x] Green — `prettier --check .` on the same tree flagged `README.md`, and `yarn lint:fix` repaired it
- [x] `yarn lint`, `yarn run check` (215 files, 0 errors), `yarn test:ci` (97.23% statements) and `yarn build` (publint clean) all pass
- [x] The pre-commit hook exercised the new `yarn lint` path when committing this change
- [x] Demo still starts: `yarn dev` serves HTTP 200 with no startup errors

## Notes

No consumer-facing change; `chore` commit, so no release is triggered.

Closes #193