### PR TITLE
chore: Scope test collection to the source tree

### DIFF
--- a/src/__tests__/vitest-config.test.ts
+++ b/src/__tests__/vitest-config.test.ts
@@ -1,0 +1,23 @@
+vi.mock('@sveltejs/kit/vite', () => ({ sveltekit: () => [] }))
+
+import config from '../../vitest.config.js'
+
+describe('vitest config', () => {
+	describe('include', () => {
+		it('scopes collection to the source tree', () => {
+			const include = config.test?.include
+
+			expect(include).toBeDefined()
+			expect(include?.length).toBeGreaterThan(0)
+			include?.forEach((pattern) => {
+				expect(pattern.startsWith('src/')).toBe(true)
+			})
+		})
+	})
+
+	describe('coverage', () => {
+		it('excludes the build output', () => {
+			expect(config.test?.coverage?.exclude).toEqual(expect.arrayContaining(['dist/**', '.svelte-kit/**']))
+		})
+	})
+})

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -5,12 +5,13 @@ export default defineConfig({
 	test: {
 		globals: true,
 		environment: 'jsdom',
+		include: ['src/**/*.{test,spec}.{js,ts}'],
 		// Automatically restore globals stubbed with vi.stubGlobal before each test,
 		// so no test file can leak a stub into the tests that follow it.
 		unstubGlobals: true,
 		coverage: {
 			reporter: ['text', 'lcov'],
-			exclude: ['src/routes/**', 'svelte.config.js', 'commitlint.config.js'],
+			exclude: ['src/routes/**', 'svelte.config.js', 'commitlint.config.js', 'dist/**', '.svelte-kit/**'],
 		},
 		setupFiles: ['./vitest.setup.js'],
 	},


### PR DESCRIPTION
## Summary

`vitest.config.js` set neither `test.include` nor `test.exclude`. Since `svelte-package` copies `src/lib/**/__tests__/**` verbatim into `dist/` and `.svelte-kit/__package__/`, and Vitest 4 narrowed its `defaultExclude` to `["**/node_modules/**", "**/.git/**"]` (Vitest 2 also carried `**/dist/**`), every suite was collected once per build directory.

Reproduced on `beta` in a built checkout: `npx vitest list --filesOnly` collected **48 files for 16 real suites** — 16 from `src/`, 16 from `dist/`, 16 from `.svelte-kit/__package__/`. After the fix, with both build directories still on disk: **17 files, all under `src/`** (16 suites plus the new guard test).

The duplicates asserted against *packaged* sources rather than `src/`, so they could pass or fail against arbitrarily stale build output. CI was unaffected only by accident — the validate action runs `yarn test:ci` before `yarn build`, and both directories are gitignored — but reordering those steps or restoring a cached workspace would have silently tripled CI.

## Changes

- `vitest.config.js` — add `include: ['src/**/*.{test,spec}.{js,ts}']`. Preferred over extending `exclude`: an include list fails closed, so a future build directory is out of scope without touching the config.
- `vitest.config.js` — add `dist/**` and `.svelte-kit/**` to `coverage.exclude`, so coverage can never be attributed to packaged copies of the sources.
- `src/__tests__/vitest-config.test.ts` — guard the invariant. Placed under `src/` so the new `include` glob collects it, but outside `src/lib/` so `svelte-package` does not ship it; `tsconfig.json` already excludes `src/**/__tests__/**`, so `yarn run check` stays clean. The sveltekit plugin is mocked because it pulls esbuild into the jsdom worker.

### Not included

The issue also suggested keeping `__tests__` out of the packaged output entirely. `@sveltejs/package` 2.5.8 has no exclusion mechanism — it does a bare directory walk of `src/lib`, and its CLI throws on a `config.package` block ("no longer supported"). That would require a post-build cleanup script tracking both output directories by hand. `package.json` already keeps tests out of the published tarball via `"!dist/**/*.test.*"` (confirmed by `publint --pack npm`), and the on-disk copies are inert once collection is scoped, so this was deliberately left out.

## Test plan

- [x] Guard test is red without the fix (`expected undefined to be defined`) and green with it
- [x] `npx vitest list --filesOnly` in a built checkout: 48 files → 17, all under `src/`
- [x] `yarn lint`
- [x] `yarn run check` — 215 files, 0 errors
- [x] `yarn test:ci` — 17 files, 458 tests passed; coverage report contains no `dist/` or `.svelte-kit/` entries
- [x] `yarn build` — `publint` all good

Closes #185