### PR TITLE
ci: Push releases as the token owner rather than the default Actions bot

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,7 @@ jobs:
             - uses: actions/checkout@v6
               with:
                   fetch-depth: 0
+                  token: ${{ secrets.GH_TOKEN }}
             - uses: ./.github/actions/validate
             - run: npx semantic-release
               env:


### PR DESCRIPTION
## Summary

The `publish` run for the #271 squash [failed](https://github.com/untemps/svelte-palette/actions/runs/33078573014/job/98539231260) at the `prepare` step of `@semantic-release/git`:

```
git push --tags https://github.com/untemps/svelte-palette.git HEAD:beta
remote: error: GH006: Protected branch update failed for refs/heads/beta.
remote: - Required status check "Validate" is expected.
```

Nothing was published: the failure happens before `publish`, so there is no `v6.0.0-beta.21` tag, no npm release and no GitHub release. `beta` carries the feature commit but no release.

## Root cause

Two credentials were in play, and the wrong one was doing the pushing.

`actions/checkout` defaults to `persist-credentials: true`, so it writes the **default** `GITHUB_TOKEN` — the `github-actions[bot]` installation token — into the local git config. semantic-release then resolves its push URL in `get-git-auth-url.js`:

```js
// Test if push is allowed without transforming the URL
try {
  await verifyAuth(repositoryUrl, branch.name, { cwd, env })   // succeeds
} catch {
  ... inject GH_TOKEN / GITHUB_TOKEN into the URL ...          // never reached
}
return repositoryUrl                                           // bare URL
```

`verifyAuth` is `git push --dry-run --no-verify -- <url> HEAD:<branch>`, and it runs **before** the release commit exists — at that point `HEAD` already matches the remote, so the dry run pushes nothing and always succeeds. An ambient credential that works therefore wins over the configured token, silently, and the bare URL in the failure log is exactly what that success path returns.

The result is a split identity:

| Channel | Identity |
| --- | --- |
| GitHub API (creating the release) | `untemps`, via the `GITHUB_TOKEN` env set to `secrets.GH_TOKEN` |
| `git push` | **`github-actions[bot]`**, via the credentials persisted by checkout |

That is why every past GitHub release is authored by `untemps` while the branch push was refused: `github-actions[bot]` is not covered by the `enforce_admins: false` exemption on `beta`, so its brand-new release commit carried no `Validate` status and the protection rejected it.

## Why it surfaced now

`Validate` became a required status check in #267. Every commit since — #267, #268, #269, #270 — is a `chore:`, which produces no release under the angular preset, so `@semantic-release/git` never had to push. #271 is the first releasable commit since the check was introduced, and the first to hit the conflict. The regression was latent, not new.

## Changes

Checking out with `GH_TOKEN` makes both channels use the same identity, so the release commit is pushed by `untemps` and covered by the existing admin exemption.

```diff
 - uses: actions/checkout@v6
   with:
       fetch-depth: 0
+      token: ${{ secrets.GH_TOKEN }}
```

No branch protection or ruleset change: `Validate` stays required on `beta` and `main`, and the bypass keeps working the way it already does for every other admin operation.

## Why not the alternatives

- **Adding `push:` triggers to `ci.yml`** cannot work. The push is rejected before any workflow can start, and the release commit carries `[skip ci]`. A required status check has to exist on the SHA at push time, which is impossible for a bot-authored commit.
- **A ruleset with an `Integration` bypass for `github-actions[bot]`** would unblock this without touching the workflow, but it grants the bypass to *every* workflow in the repository using the default token — a real widening of the surface for a problem caused by the wrong identity pushing.
- **Dropping `@semantic-release/git`** removes the branch push entirely (semantic-release core only pushes tags, which branch protection does not cover), but freezes `CHANGELOG.md` and the in-repo `version` at `6.0.0-beta.20`.

## Test plan

- [x] `npx prettier --check .github/workflows/publish.yml`
- [x] Pre-commit hook green (lint, `svelte-check`, full vitest, build)
- [x] Root cause verified against the installed sources rather than inferred: `get-git-auth-url.js` returns the bare URL on the `verifyAuth` success path, `verifyAuth` is a dry-run push made before the release commit exists, and `actions/checkout@v6` still defaults `persist-credentials` to `true`
- [x] Confirmed `semantic-release` core pushes tags only (`git push --tags -- <url>`); the `HEAD:beta` in the failing command comes solely from `@semantic-release/git`
- [ ] **Only verifiable on merge.** Merging this pushes to `beta`, which triggers `publish` with the fixed workflow; semantic-release will find the still-untagged `feat:` + `BREAKING CHANGE` from 759137d and cut `6.0.0-beta.21`. Re-running the failed job would *not* pick this up — a rerun uses the workflow file from its triggering commit.

If the push is still refused, it means `enforce_admins: false` does not exempt admins from required status checks on a direct push, and the fallback is a ruleset with a narrow `User` bypass for `untemps`. The logs will say which: a push URL carrying credentials confirms the identity switched.

Refs #271
